### PR TITLE
Workaround to remove mvnpm deps from target quarkus app

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
     <formatter.plugin.version>2.23.0</formatter.plugin.version>
     <impsort.plugin.version>1.9.0</impsort.plugin.version>
     <quarkus.ide-config.version>3.0.0.Final</quarkus.ide-config.version>
+    <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <!-- UI Libs -->
     <quarkus-qute-server-pages.version>2.1.0.Final</quarkus-qute-server-pages.version>
     <quarkus-web-bundler.version>1.1.5</quarkus-web-bundler.version>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,31 @@
           </compilerArgs>
         </configuration>
       </plugin>
+      <!-- Workaround for web-bundler (removing mvnpm deps from target quarkus-app) -->
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>${maven-antrun-plugin.version}</version>
+          <executions>
+              <execution>
+                  <id>delete-mvnpm-deps</id>
+                  <phase>package</phase>
+                  <goals>
+                      <goal>run</goal>
+                  </goals>
+                  <configuration>
+                      <target>
+                          <!-- Delete libraries starting with org.mvnpm -->
+                          <delete includeemptydirs="true">
+                              <fileset dir="${project.build.directory}/quarkus-app/lib/main">
+                                  <include name="org.mvnpm*"/>
+                              </fileset>
+                          </delete>
+                      </target>
+                  </configuration>
+              </execution>
+          </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefire-plugin.version}</version>


### PR DESCRIPTION
I haven't tested it in native but I think it should work