### PR TITLE
Add .d.ts.map to .more.tgz

### DIFF
--- a/src/main/java/io/mvnpm/file/type/JarClient.java
+++ b/src/main/java/io/mvnpm/file/type/JarClient.java
@@ -246,7 +246,7 @@ public class JarClient {
     private final int bufferSize = 4096;
 
     // Files to add in a tgz compressed file in the jar
-    static final List<String> FILES_TO_TGZ = List.of(".d.ts");
+    static final List<String> FILES_TO_TGZ = List.of(".d.ts", ".d.ts.map");
 
     // Excluded files which won't be added to the jar (unless gzipped)
     static final List<String> FILES_TO_EXCLUDE = List.of(".md", ".ts", ".ts.map", "/logo.svg");


### PR DESCRIPTION
I did not expect but this is needed for IDEs support of typescript, the impact is not significant and it is only used in a few libraries like Lit.

lit-element: 55KB to 57KB
lit: 71KB to 75KB


