### PR TITLE
Add .d.ts.map to .more.tgz

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.9.1</quarkus.platform.version>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>3.9.2</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.2.5</surefire-plugin.version>
     <formatter.plugin.version>2.23.0</formatter.plugin.version>

--- a/src/main/java/io/mvnpm/file/type/JarClient.java
+++ b/src/main/java/io/mvnpm/file/type/JarClient.java
@@ -249,7 +249,7 @@ public class JarClient {
     private final int bufferSize = 4096;
 
     // Files to add in a tgz compressed file in the jar
-    static final List<String> FILES_TO_TGZ = List.of(".d.ts");
+    static final List<String> FILES_TO_TGZ = List.of(".d.ts", ".d.ts.map");
 
     // Excluded files which won't be added to the jar (unless gzipped)
     static final List<String> FILES_TO_EXCLUDE = List.of(".md", ".ts", ".ts.map", "/logo.svg");


### PR DESCRIPTION
I did not expect but this is needed for IDEs support of typescript, the impact is not significant and it is only used in a few libraries like Lit.

lit-element: 55KB to 57KB
lit: 71KB to 75KB

**I am re-adding this because in the end it's needed, it's just the IDE cache which mislead me into thinking it was working without.** 