### PR TITLE
Setup http settings (cache and compression)

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -50,6 +50,37 @@ mvnpm.checkall.cron.expr=0 0 0/4 * * ?
 %mvnpm.checkerror.cron.expr=0 0/1 * * * ?
 mvnpm.checkerror.cron.expr=0 0 5 * * ?
 
+quarkus.http.enable-compression=true
+quarkus.http.filter.others.header.Cache-Control=no-cache
+quarkus.http.filter.others.matches=/.*
+quarkus.http.filter.others.methods=GET
+quarkus.http.filter.others.order=0
+
+quarkus.http.filter.static.header.Cache-Control=max-age=31536000
+quarkus.http.filter.static.matches=/static/.+
+quarkus.http.filter.static.methods=GET
+quarkus.http.filter.static.order=1
+
+quarkus.http.filter.api.header.Cache-Control=max-age=31536000
+quarkus.http.filter.api.header."X-Content-Type-Options"=nosniff
+quarkus.http.filter.api.header."X-Frame-Options"=deny
+quarkus.http.filter.api.header."Strict-Transport-Security"=max-age=31536000; includeSubDomains
+quarkus.http.filter.api.header."Content-Security-Policy"=default-src 'none';
+quarkus.http.filter.api.matches=/api/.+
+quarkus.http.filter.api.order=1
+
+quarkus.http.filter.backup.header.Cache-Control=no-cache
+quarkus.http.filter.backup.matches=/api/backup
+quarkus.http.filter.backup.order=2
+
+quarkus.http.filter.maven.header.Cache-Control=max-age=31536000
+quarkus.http.filter.maven.matches=/maven2/.+
+quarkus.http.filter.maven.order=1
+
+quarkus.http.filter.maven-meta.header.Cache-Control=no-cache
+quarkus.http.filter.maven-meta.matches=/maven2/.+/maven-metadata.xml
+quarkus.http.filter.maven-meta.order=2
+
 quarkus.http.read-timeout=5M
 quarkus.rest-client.read-timeout=500000
 quarkus.vertx.max-worker-execute-time=5M


### PR DESCRIPTION
- no cache by default
- cache on /static stuff
- cache on /api by default
- no cache on backup
- cache on all maven2
- no cache on metadata in maven2


(cloudflare is following the headers rules)