### PR TITLE
Introduce live-sync checkbox

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     
     <pgpainless.version>1.5.5</pgpainless.version>
     <!-- UI Libs -->
-    <quarkus-web-bundler.version>1.7.0</quarkus-web-bundler.version>
+    <quarkus-web-bundler.version>1.7.2</quarkus-web-bundler.version>
     <lit.version>3.2.0</lit.version>
     <vaadin.version>24.4.5</vaadin.version>
     <ldrs.version>1.0.2</ldrs.version>
@@ -74,7 +74,7 @@
     <badge.version>1.0.2</badge.version>
     <!-- Testing-->
     <playwright.version>0.0.1</playwright.version>
-    <esbuild-java.version>1.4.3</esbuild-java.version>
+    <esbuild-java.version>1.5.0</esbuild-java.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/src/main/java/io/mvnpm/mavencentral/sync/CentralSyncApi.java
+++ b/src/main/java/io/mvnpm/mavencentral/sync/CentralSyncApi.java
@@ -1,8 +1,5 @@
 package io.mvnpm.mavencentral.sync;
 
-import static io.mvnpm.Constants.HEADER_CACHE_CONTROL;
-import static io.mvnpm.Constants.HEADER_CACHE_CONTROL_IMMUTABLE;
-
 import java.util.List;
 import java.util.Set;
 
@@ -20,7 +17,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
 
 import org.jboss.resteasy.reactive.NoCache;
-import org.jboss.resteasy.reactive.ResponseHeader;
 
 import io.mvnpm.npm.NpmRegistryFacade;
 import io.mvnpm.npm.model.Name;

--- a/src/main/java/io/mvnpm/mavencentral/sync/CentralSyncItem.java
+++ b/src/main/java/io/mvnpm/mavencentral/sync/CentralSyncItem.java
@@ -1,12 +1,5 @@
 package io.mvnpm.mavencentral.sync;
 
-import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.IdClass;
-import jakarta.persistence.NamedQueries;
-import jakarta.persistence.NamedQuery;
-
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -14,6 +7,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 @Entity
 @IdClass(Gav.class)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,9 @@ quarkus.rest-client.sonatype.connect-timeout=30000
 quarkus.rest-client.github.url=https://api.github.com
 quarkus.rest-client.github.verify-host=false
 
+quarkus.websocket.dispatch-to-worker=true
+quarkus.scheduler.start-mode=forced
+
 %dev.mvnpm.local-user-directory=target
 %test.mvnpm.local-user-directory=target
 %prod.mvnpm.local-user-directory=/opt/mvnpm
@@ -56,12 +59,12 @@ quarkus.http.enable-compression=true
 quarkus.http.filter.index.header."Cache-Control"=no-cache
 quarkus.http.filter.index.matches=/
 quarkus.http.filter.index.methods=GET
-quarkus.http.filter.static.header."Cache-Control"=public, max-age=604800
-quarkus.http.filter.static.matches=/static/(?!bundle/.+).+
-quarkus.http.filter.static.methods=GET
-quarkus.http.filter.bundle.header."Cache-Control"=public, max-age=31536000, immutable
-quarkus.http.filter.bundle.matches=/static/bundle/.+
-quarkus.http.filter.bundle.methods=GET
+%prod.quarkus.http.filter.static.header."Cache-Control"=public, max-age=604800
+%prod.quarkus.http.filter.static.matches=/static/(?!bundle/.+).+
+%prod.quarkus.http.filter.static.methods=GET
+%prod.quarkus.http.filter.bundle.header."Cache-Control"=public, max-age=31536000, immutable
+%prod.quarkus.http.filter.bundle.matches=/static/bundle/.+
+%prod.quarkus.http.filter.bundle.methods=GET
 
 quarkus.http.filter.api.header."X-Content-Type-Options"=nosniff
 quarkus.http.filter.api.header."X-Frame-Options"=deny

--- a/src/main/resources/web/app/mvnpm-doc.ts
+++ b/src/main/resources/web/app/mvnpm-doc.ts
@@ -5,6 +5,7 @@ import '@qomponent/qui-code-block';
 /**
  * This component shows the Doc screen
  */
+
 @customElement('mvnpm-doc')
 export class MvnpmDoc extends LitElement {
 

--- a/src/main/resources/web/app/mvnpm-event-log.ts
+++ b/src/main/resources/web/app/mvnpm-event-log.ts
@@ -1,114 +1,174 @@
-import { LitElement, html, css } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import {LitElement, html, css} from 'lit';
+import {customElement, state, property} from 'lit/decorators.js';
+
+export const WEBSOCKET_BASE = window.location.protocol === "https:" ? "wss:" : "ws:" + "//" + window.location.host;
 
 /**
  * This component shows the Event log
  */
 @customElement('mvnpm-event-log')
 export class MvnpmEventLog extends LitElement {
-    static styles = css`
-    :host {
-      display: flex;
-      gap: 10px;
-      width: 100%;
-      max-height: 40vh;
-      background: black;
-    }
-    .console {
-      display: flex;
-      flex-direction: column;
-      width: 100%;
-      height: 100%;
-      padding-left: 20px;
-      padding-right: 20px;
-      background: black;
-      font-family: 'Courier New', monospace;
-      font-size: small;
-      filter: brightness(0.85);
-    }
-    .line {
-        display: flex;
-        flex-direction: row;
-        gap: 10px;
-    }
+  static styles = css`
+      :host {
+          display: flex;
+          gap: 10px;
+          width: 100%;
+          max-height: 40vh;
+          background: black;
+      }
+
+      .console {
+          display: flex;
+          flex-direction: column;
+          width: 100%;
+          height: 100%;
+          padding-left: 20px;
+          padding-right: 20px;
+          background: black;
+          font-family: 'Courier New', monospace;
+          font-size: small;
+          filter: brightness(0.85);
+      }
+
+      .line {
+          display: flex;
+          flex-direction: row;
+          gap: 10px;
+      }
 
   `;
 
-    @state({ type: Array })
-    private _initEventLog: any[] | null = null;
+  private _logWebSocket = null;
 
-    private _eventLogEntry = (event: CustomEvent) => this._receiveLogEntry(event.detail);
+  @state({type: Array})
+  private _initEventLog: any[] | null = null;
 
-    constructor() {
-        super();
+  @property({type: Boolean})
+  private liveSync;
+
+  private _eventLogEntry = (event: CustomEvent) => this._receiveLogEntry(event.detail);
+
+  constructor() {
+    super();
+
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    fetch("/api/eventlog/top")
+      .then(response => response.json())
+      .then(initEventLog => (this._initEventLog = this._addMultipleToLog(this._initEventLog, initEventLog)));
+
+    document.addEventListener('eventLogEntryEvent', this._eventLogEntry, false);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._stopLiveSync();
+    document.removeEventListener('eventLogEntryEvent', this._eventLogEntry, false);
+  }
+
+  updated(changedProps) {
+    if (this.liveSync) {
+      this._startLiveSync();
+    } else {
+      this._stopLiveSync();
     }
+  }
 
-    connectedCallback() {
-        super.connectedCallback();
-
-        fetch("/api/eventlog/top")
-            .then(response => response.json())
-            .then(initEventLog => (this._initEventLog = this._addMultipleToLog(this._initEventLog, initEventLog)));
-        
-        document.addEventListener('eventLogEntryEvent', this._eventLogEntry, false);
+  private _startLiveSync() {
+    if (!this._logWebSocket) {
+      this._logWebSocket = new WebSocket(WEBSOCKET_BASE + "/api/stream/eventlog");
+      this._logWebSocket.onmessage = function (event) {
+        var eventLogEntry = JSON.parse(event.data);
+        const eventLogEntryEvent = new CustomEvent('eventLogEntryEvent', {detail: eventLogEntry});
+        document.dispatchEvent(eventLogEntryEvent);
+      }
+      this._logWebSocket.onclose = function (event) {
+        setTimeout(function () {
+          if (this.liveSync) {
+            this._startLiveSync();
+          }
+        }, 100);
+      };
     }
+  }
 
-    disconnectedCallback() {
-        super.disconnectedCallback();
-        document.removeEventListener('eventLogEntryEvent', this._eventLogEntry, false);
+  private _stopLiveSync() {
+    if (this._logWebSocket) {
+      this._logWebSocket.close();
+      this._logWebSocket = null;
     }
+  }
 
-    private _receiveLogEntry(initEventLog: any) {
-        this._initEventLog = this._addToLog(this._initEventLog, initEventLog);
-    }
 
-    render() {
-        return html`
+  private _receiveLogEntry(initEventLog: any) {
+    this._initEventLog = this._addToLog(this._initEventLog, initEventLog);
+  }
+
+  render() {
+    return html`
       <div class="console">
         ${this._renderInitEventLog()}
       </div>
     `;
-    }
+  }
 
-    private _renderInitEventLog() {
-        if (this._initEventLog && this._initEventLog.length > 0) {
-            return html`
-                ${this._initEventLog.map((entry) => {
-                    return html`${this._renderLine(entry)}`
-                })}
-              `;
-        } else {
-            return html`<p>Nothing in the event log</p>`;
-        }
+  private _renderInitEventLog() {
+    if (this._initEventLog && this._initEventLog.length > 0) {
+      return html`
+        <l-dot-stream
+            size="20"
+            speed="2.5"
+            color="#66a5b1"
+        ></l-dot-stream><br/>
+        ${this._initEventLog.map((entry) => {
+          return html`${this._renderLine(entry)}`
+        })}
+      `;
+    } else if (this.liveSync) {
+      return html`
+        <p>Nothing in the event log <br/>
+          <l-dot-stream
+              size="20"
+              speed="2.5"
+              color="#66a5b1"
+          ></l-dot-stream>
+        </p>`;
+    } else {
+      return html`<p>Nothing in the event log</p>`;
     }
+  }
 
-    private _renderLine(entry){
-        let formattedTime = entry.time.substring(0, entry.time.indexOf(".")).replace('T',' ');
-        
-        return html`<div class="line">
-                        <span style="color: grey">${formattedTime}</span>
-                        <span style="color: lightblue">${entry.groupId}</span>
-                        <span style="color: lightyellow">${entry.artifactId}</span>
-                        <span style="color: lightpink">${entry.version}</span>
-                        <span style="color: lightgrey">[${entry.stage}]</span>
-                        <span style="color: ${entry.color}">${entry.message}</span>
-                    </div>`;
-    }
+  private _renderLine(entry) {
+    let formattedTime = entry.time.substring(0, entry.time.indexOf(".")).replace('T', ' ');
 
-    private _addToLog(queue: any[] | null, item: any) {
-        if (queue && queue.length > 0) {
-            return [item, ...queue];
-        } else {
-            return [item];
-        }
-    }
+    return html`
+      <div class="line">
+        <span style="color: grey">${formattedTime}</span>
+        <span style="color: lightblue">${entry.groupId}</span>
+        <span style="color: lightyellow">${entry.artifactId}</span>
+        <span style="color: lightpink">${entry.version}</span>
+        <span style="color: lightgrey">[${entry.stage}]</span>
+        <span style="color: ${entry.color}">${entry.message}</span>
+      </div>`;
+  }
 
-    private _addMultipleToLog(queue: any[] | null, items: any[]) {
-        if (queue && queue.length > 0) {
-            return [...items, ...queue];
-        } else {
-            return items;
-        }
+  private _addToLog(queue: any[] | null, item: any) {
+    if (queue && queue.length > 0) {
+      return [item, ...queue];
+    } else {
+      return [item];
     }
+  }
+
+  private _addMultipleToLog(queue: any[] | null, items: any[]) {
+    if (queue && queue.length > 0) {
+      return [...items, ...queue];
+    } else {
+      return items;
+    }
+  }
 
 }

--- a/src/main/resources/web/app/mvnpm-live.ts
+++ b/src/main/resources/web/app/mvnpm-live.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/split-layout';
+import '@vaadin/checkbox';
 import './mvnpm-event-log.js';
 import './mvnpm-progress.js';
 
@@ -10,20 +11,38 @@ import './mvnpm-progress.js';
 @customElement('mvnpm-live')
 export class MvnpmLive extends LitElement {
     static styles = css`
-    :host {
-      display: flex;
-      flex-direction: column;
-      gap: 10px;
-      width: 100%;
-      padding: 20px;
-    }`;
+        :host {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            width: 100%;
+            padding: 20px;
+        }
+
+        .live-sync {
+            display: flex;
+            justify-content: center;
+        }
+    `;
+
+    @state({type: Boolean})
+    private _liveSync;
 
     render() {
+
         return html`
-            <vaadin-split-layout style="height: 100%;" orientation="vertical">
-                <mvnpm-progress></mvnpm-progress>
-                <mvnpm-event-log></mvnpm-event-log>
-            </vaadin-split-layout>`;
+                <div class="live-sync">
+                    <vaadin-checkbox label="Live sync" @checked-changed="${this._liveSyncChange}"></vaadin-checkbox>
+                </div>
+                <vaadin-split-layout style="height: 100%;" orientation="vertical">
+                    <mvnpm-progress .liveSync=${this._liveSync}></mvnpm-progress>
+                    <mvnpm-event-log .liveSync=${this._liveSync}></mvnpm-event-log>
+                </vaadin-split-layout>
+         `;
+    }
+
+    private _liveSyncChange = (event) => {
+        this._liveSync = event.target.checked;
     }
 
 }

--- a/src/main/resources/web/app/mvnpm-nav.ts
+++ b/src/main/resources/web/app/mvnpm-nav.ts
@@ -1,6 +1,6 @@
-import { LitElement, html, css} from 'lit';
-import { customElement } from 'lit/decorators.js';
-import { Router } from '@vaadin/router';
+import {LitElement, html, css} from 'lit';
+import {customElement, state} from 'lit/decorators.js';
+import {Router} from '@vaadin/router';
 import './mvnpm-home.js';
 import './mvnpm-releases.js';
 import './mvnpm-live.js';
@@ -13,13 +13,13 @@ if (indicator.length > 0) {
 
 const router = new Router(document.getElementById('outlet'));
 router.setRoutes([
-    {path: '/', component: 'mvnpm-home', name: 'Browse'},
-    {path: '/package/:package', component: 'mvnpm-home', name: 'Browse'},
-    {path: '/search/:name', component: 'mvnpm-home', name: 'Browse'},
-    {path: '/doc', component: 'mvnpm-doc', name: 'Getting Started'},
-    {path: '/releases', component: 'mvnpm-releases', name: 'Releases'},
-    {path: '/live', component: 'mvnpm-live', name: 'Live'},
-    {path: '/composites', component: 'mvnpm-composites', name: 'Composites'},
+  {path: '/', component: 'mvnpm-home', name: 'Browse'},
+  {path: '/package/:package', component: 'mvnpm-home', name: 'Browse'},
+  {path: '/search/:name', component: 'mvnpm-home', name: 'Browse'},
+  {path: '/doc', component: 'mvnpm-doc', name: 'Getting Started'},
+  {path: '/releases', component: 'mvnpm-releases', name: 'Releases'},
+  {path: '/live', component: 'mvnpm-live', name: 'Live'},
+  {path: '/composites', component: 'mvnpm-composites', name: 'Composites'},
 ]);
 
 /**
@@ -28,78 +28,46 @@ router.setRoutes([
 @customElement('mvnpm-nav')
 export class MvnpmNav extends LitElement {
 
-    static syncWebSocket;
-    static syncServerUri;
 
-    static logWebSocket;
-    static logServerUri;
 
-    constructor() {
-      super();
-      if (!MvnpmNav.syncWebSocket) {
-          if (window.location.protocol === "https:") {
-            MvnpmNav.syncServerUri = "wss:";
-          } else {
-            MvnpmNav.syncServerUri = "ws:";
+
+  @state({type: Object}) location = router.location;
+
+  constructor() {
+    super();
+
+
+    router.ready.then(() => {
+      this.location = router.location;
+    });
+  }
+
+
+  render() {
+    const routes = router.getRoutes();
+    return html`
+      <vaadin-tabs .selected=${undefined}>
+        ${routes.map((r) => {
+          let ignore = r.path.includes(":");
+          if (!ignore) {
+            const selected = this._isCurrentLocation(r);
+            return html`
+              <vaadin-tab .selected=${selected}>
+                <a href="${r.path}">
+                  <span>${r.name}</span>
+                </a>
+              </vaadin-tab>`;
           }
-          MvnpmNav.syncServerUri += "//" + window.location.host + "/api/queue/";
-          MvnpmNav.connectSync();
-      }
-      if (!MvnpmNav.logWebSocket) {
-          if (window.location.protocol === "https:") {
-            MvnpmNav.logServerUri = "wss:";
-          } else {
-            MvnpmNav.logServerUri = "ws:";
-          }
-          MvnpmNav.logServerUri += "//" + window.location.host + "/api/stream/eventlog";
-          MvnpmNav.connectLog();
-      }
-    }    
+        })}
+        <vaadin-tab>
+          <a href="https://github.com/mvnpm/mvnpm" target="_blank" vaadin-router-ignore><span>Source</span></a>
+        </vaadin-tab>
+      </vaadin-tabs>`;
+  }
 
-    render() {
-        const routes = router.getRoutes();
-        return html`<vaadin-tabs> 
-                        ${routes.map((r) => {
-                            let ignore = r.path.includes(":");
-                            if(!ignore){
-                                return html`<vaadin-tab>
-                                        <a href="${r.path}">
-                                            <span>${r.name}</span>
-                                        </a>
-                                    </vaadin-tab>`;
-                            }
-                        })}
-                        <vaadin-tab>
-                          <a href="https://github.com/mvnpm/mvnpm" target="_blank" vaadin-router-ignore><span>Source</span></a>
-                        </vaadin-tab>
-                    </vaadin-tabs>`;
-    }
+  private _isCurrentLocation = (route) => {
+    return router.urlForPath(route.path) === this.location.getUrl();
+  }
 
-    static connectSync() {
-        MvnpmNav.syncWebSocket = new WebSocket(MvnpmNav.syncServerUri);
-        MvnpmNav.syncWebSocket.onmessage = function (event) {
-            var centralSyncItem = JSON.parse(event.data);
-            const centralSyncStateChangeEvent = new CustomEvent('centralSyncStateChange', {detail: centralSyncItem});
-            document.dispatchEvent(centralSyncStateChangeEvent);
-        }
-        MvnpmNav.syncWebSocket.onclose = function (event) {
-            setTimeout(function () {
-                MvnpmNav.connectSync();
-            }, 100);
-        };
-    }
-    
-    static connectLog() {
-        MvnpmNav.logWebSocket = new WebSocket(MvnpmNav.logServerUri);
-        MvnpmNav.logWebSocket.onmessage = function (event) {
-            var eventLogEntry = JSON.parse(event.data);
-            const eventLogEntryEvent = new CustomEvent('eventLogEntryEvent', {detail: eventLogEntry});
-            document.dispatchEvent(eventLogEntryEvent);
-        }
-        MvnpmNav.logWebSocket.onclose = function (event) {
-            setTimeout(function () {
-                MvnpmNav.connectLog();
-            }, 100);
-        };
-    }
- }
+
+}

--- a/src/main/resources/web/app/mvnpm-progress.ts
+++ b/src/main/resources/web/app/mvnpm-progress.ts
@@ -1,8 +1,9 @@
-import { LitElement, html, css } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import {LitElement, html, css} from 'lit';
+import {customElement, state, property} from 'lit/decorators.js';
 import '@vaadin/progress-bar';
 import '@vaadin/message-list';
-import { dotStream } from 'ldrs';
+import {dotStream} from 'ldrs';
+import {WEBSOCKET_BASE} from "./mvnpm-event-log";
 
 dotStream.register();
 
@@ -11,125 +12,174 @@ dotStream.register();
  */
 @customElement('mvnpm-progress')
 export class MvnpmProgress extends LitElement {
-    static styles = css`
-    :host {
-      display: flex;
-      gap: 10px;
-      width: 100%;
-    }
-    .lane {
-      display: flex;
-      gap: 10px;
-      flex-direction: column;
-      width: 100%;
-      height: 100%;
-      padding-left: 20px;
-      padding-right: 20px;
-      align-items: center;
-    }
-    .maven-central {
-        width: 100%;
-        display: flex;
-        gap: 10px;
-        flex-direction: column;
-        width: 100%;
-        height: 100%;
-        padding-left: 20px;
-        padding-right: 20px;
-        align-items: center;
-        overflow-y: scroll;
-    }
-    .maven-central-message-box {
-        width: 100%;
-        overflow-y: unset;
-    }
-    .uploading {
-      border-right: 2px solid var(--lumo-contrast-10pct);
-      border-left: 2px solid var(--lumo-contrast-10pct);
-    }
-    .progressBar {
-      width: 50%;
-    }
-    vaadin-message-list {
-        width: 100%;
-    }
+
+
+  static styles = css`
+      :host {
+          display: flex;
+          gap: 10px;
+          width: 100%;
+      }
+
+      .lane {
+          display: flex;
+          gap: 10px;
+          flex-direction: column;
+          width: 100%;
+          height: 100%;
+          padding-left: 20px;
+          padding-right: 20px;
+          align-items: center;
+      }
+
+      .maven-central {
+          width: 100%;
+          display: flex;
+          gap: 10px;
+          flex-direction: column;
+          width: 100%;
+          height: 100%;
+          padding-left: 20px;
+          padding-right: 20px;
+          align-items: center;
+          overflow-y: scroll;
+      }
+
+      .maven-central-message-box {
+          width: 100%;
+          overflow-y: unset;
+      }
+
+      .uploading {
+          border-right: 2px solid var(--lumo-contrast-10pct);
+          border-left: 2px solid var(--lumo-contrast-10pct);
+      }
+
+      .progressBar {
+          width: 50%;
+      }
+
+      vaadin-message-list {
+          width: 100%;
+      }
   `;
 
-    @state({ type: Array })
-    private _initQueue: any[] | null = null;
+  private _syncWebSocket = null;
 
-    @state({ type: Array })
-    private _uploadingQueue: any[] | null = null;
+  @state({type: Array})
+  private _initQueue: any[] | null = null;
 
-    @state({ type: Array })
-    private _uploadedQueue: any[] | null = null;
+  @state({type: Array})
+  private _uploadingQueue: any[] | null = null;
 
-    @state({ type: Array })
-    private _closedQueue: any[] | null = null;
+  @state({type: Array})
+  private _uploadedQueue: any[] | null = null;
 
-    @state({ type: Array })
-    private _releasingQueue: any[] | null = null;
+  @state({type: Array})
+  private _closedQueue: any[] | null = null;
 
-    @state({ type: Array })
-    private _releasedQueue: any[] | null = null;
+  @state({type: Array})
+  private _releasingQueue: any[] | null = null;
 
-    private _centralSyncStateChange = (event: CustomEvent) => this._receiveStateChange(event.detail);
+  @state({type: Array})
+  private _releasedQueue: any[] | null = null;
 
-    constructor() {
-        super();
+  @property({type: Boolean})
+  private liveSync;
+
+  private _centralSyncStateChange = (event: CustomEvent) => this._receiveStateChange(event.detail);
+
+  constructor() {
+    super();
+  }
+
+  updated(changedProps) {
+    if (this.liveSync) {
+      this._startLiveSync();
+    } else {
+      this._stopLiveSync();
     }
+  }
 
-    connectedCallback() {
-        super.connectedCallback();
-
-        fetch("/api/sync/item/INIT")
-            .then(response => response.json())
-            .then(initQueue => (this._initQueue = this._addMultipleToQueue(this._initQueue, initQueue, "Waiting...", 1)));
-        fetch("/api/sync/item/UPLOADING")
-            .then(response => response.json())
-            .then(uploadingQueue => (this._uploadingQueue = this._addMultipleToQueue(this._uploadingQueue, uploadingQueue, "Uploading to maven central...", 2)));
-        fetch("/api/sync/item/UPLOADED")
-            .then(response => response.json())
-            .then(uploadedQueue => (this._uploadedQueue = this._addMultipleToQueue(this._uploadedQueue, uploadedQueue, "Uploaded, validating...", 3)));
-        fetch("/api/sync/item/CLOSED")
-            .then(response => response.json())
-            .then(closedQueue => (this._closedQueue = this._addMultipleToQueue(this._closedQueue, closedQueue, "Valid, preparing release...", 4)));
-        fetch("/api/sync/item/RELEASING")
-            .then(response => response.json())
-            .then(releasingQueue => (this._releasingQueue = this._addMultipleToQueue(this._releasingQueue, releasingQueue, "Releasing to maven central...", 5)));
-
-        document.addEventListener('centralSyncStateChange', this._centralSyncStateChange, false);
+  private _startLiveSync() {
+    if (!this._syncWebSocket) {
+      this._syncWebSocket = new WebSocket(WEBSOCKET_BASE + "/api/queue/");
+      this._syncWebSocket.onmessage = function (event) {
+        var centralSyncItem = JSON.parse(event.data);
+        const centralSyncStateChangeEvent = new CustomEvent('centralSyncStateChange', {detail: centralSyncItem});
+        document.dispatchEvent(centralSyncStateChangeEvent);
+      }
+      const that = this;
+      this._syncWebSocket.onclose = function (event) {
+        setTimeout(function () {
+          if (that.liveSync) {
+            that._syncWebSocket = null;
+            that._startLiveSync();
+          }
+        }, 100);
+      };
     }
+  }
 
-    disconnectedCallback() {
-        super.disconnectedCallback();
-        document.removeEventListener('centralSyncStateChange', this._centralSyncStateChange, false);
+  private _stopLiveSync() {
+    if (this._syncWebSocket) {
+      this._syncWebSocket.close();
+      this._syncWebSocket = null;
     }
+  }
 
-    private _receiveStateChange(centralSyncItem: any) {
-        if (centralSyncItem.stage === "INIT") {
-            this._uploadingQueue = this._removeFromQueue(this._uploadingQueue, centralSyncItem);
-            this._initQueue = this._addToQueue(this._initQueue, centralSyncItem, "Waiting...", 1);
-        } else if (centralSyncItem.stage === "UPLOADING") {
-            this._initQueue = this._removeFromQueue(this._initQueue, centralSyncItem);
-            this._uploadingQueue = this._addToQueue(this._uploadingQueue, centralSyncItem, "Uploading to maven central", 2);
-        } else if (centralSyncItem.stage === "UPLOADED") {
-            this._uploadingQueue = this._removeFromQueue(this._uploadingQueue, centralSyncItem);
-            this._uploadedQueue = this._addToQueue(this._uploadedQueue, centralSyncItem, "Uploaded, validating...", 3);
-        } else if (centralSyncItem.stage === "CLOSED") {
-            this._uploadedQueue = this._removeFromQueue(this._uploadedQueue, centralSyncItem);
-            this._closedQueue = this._addToQueue(this._closedQueue, centralSyncItem, "Valid, preparing release...", 4);
-        } else if (centralSyncItem.stage === "RELEASING") {
-            this._closedQueue = this._removeFromQueue(this._closedQueue, centralSyncItem);
-            this._releasingQueue = this._addToQueue(this._releasingQueue, centralSyncItem, "Releasing to maven central...", 5);
-        } else if (centralSyncItem.stage === "RELEASED") {
-            this._releasingQueue = this._removeFromQueue(this._releasingQueue, centralSyncItem);
-            this._releasedQueue = this._addToQueue(this._releasedQueue, centralSyncItem, "Released.", 6);
-        }
+  connectedCallback() {
+    super.connectedCallback();
+
+    fetch("/api/sync/item/INIT")
+      .then(response => response.json())
+      .then(initQueue => (this._initQueue = this._addMultipleToQueue(this._initQueue, initQueue, "Waiting...", 1)));
+    fetch("/api/sync/item/UPLOADING")
+      .then(response => response.json())
+      .then(uploadingQueue => (this._uploadingQueue = this._addMultipleToQueue(this._uploadingQueue, uploadingQueue, "Uploading to maven central...", 2)));
+    fetch("/api/sync/item/UPLOADED")
+      .then(response => response.json())
+      .then(uploadedQueue => (this._uploadedQueue = this._addMultipleToQueue(this._uploadedQueue, uploadedQueue, "Uploaded, validating...", 3)));
+    fetch("/api/sync/item/CLOSED")
+      .then(response => response.json())
+      .then(closedQueue => (this._closedQueue = this._addMultipleToQueue(this._closedQueue, closedQueue, "Valid, preparing release...", 4)));
+    fetch("/api/sync/item/RELEASING")
+      .then(response => response.json())
+      .then(releasingQueue => (this._releasingQueue = this._addMultipleToQueue(this._releasingQueue, releasingQueue, "Releasing to maven central...", 5)));
+
+    document.addEventListener('centralSyncStateChange', this._centralSyncStateChange, false);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._stopLiveSync();
+    document.removeEventListener('centralSyncStateChange', this._centralSyncStateChange, false);
+  }
+
+  private _receiveStateChange(centralSyncItem: any) {
+    if (centralSyncItem.stage === "INIT") {
+      this._uploadingQueue = this._removeFromQueue(this._uploadingQueue, centralSyncItem);
+      this._initQueue = this._addToQueue(this._initQueue, centralSyncItem, "Waiting...", 1);
+    } else if (centralSyncItem.stage === "UPLOADING") {
+      this._initQueue = this._removeFromQueue(this._initQueue, centralSyncItem);
+      this._uploadingQueue = this._addToQueue(this._uploadingQueue, centralSyncItem, "Uploading to maven central", 2);
+    } else if (centralSyncItem.stage === "UPLOADED") {
+      this._uploadingQueue = this._removeFromQueue(this._uploadingQueue, centralSyncItem);
+      this._uploadedQueue = this._addToQueue(this._uploadedQueue, centralSyncItem, "Uploaded, validating...", 3);
+    } else if (centralSyncItem.stage === "CLOSED") {
+      this._uploadedQueue = this._removeFromQueue(this._uploadedQueue, centralSyncItem);
+      this._closedQueue = this._addToQueue(this._closedQueue, centralSyncItem, "Valid, preparing release...", 4);
+    } else if (centralSyncItem.stage === "RELEASING") {
+      this._closedQueue = this._removeFromQueue(this._closedQueue, centralSyncItem);
+      this._releasingQueue = this._addToQueue(this._releasingQueue, centralSyncItem, "Releasing to maven central...", 5);
+    } else if (centralSyncItem.stage === "RELEASED") {
+      this._releasingQueue = this._removeFromQueue(this._releasingQueue, centralSyncItem);
+      this._releasedQueue = this._addToQueue(this._releasedQueue, centralSyncItem, "Released.", 6);
     }
+  }
 
-    render() {
-        return html`
+  render() {
+    return html`
       <div class="lane">
         <h3>Queue</h3>
         ${this._renderInitQueue()}
@@ -142,95 +192,100 @@ export class MvnpmProgress extends LitElement {
         ${this._renderMavenCentral()}
       </div>
     `;
+  }
+
+  private _renderInitQueue() {
+    if (this._initQueue && this._initQueue.length > 0) {
+      return html`
+        <vaadin-message-list .items="${this._initQueue}"></vaadin-message-list>
+        <l-dot-stream
+            size="30"
+            speed="2.5"
+            color="#66a5b1"
+        ></l-dot-stream>`;
+    } else if (this.liveSync) {
+      return html`
+        <l-dot-stream
+            size="40"
+            speed="2.5"
+            color="#66a5b1"
+        ></l-dot-stream> <br/>Waiting for items
+      `;
+    } else {
+      return html`No items`;
+    }
+  }
+
+  private _renderUploading() {
+    if (this._uploadingQueue && this._uploadingQueue.length > 0) {
+      return html`
+        <vaadin-progress-bar class="progressBar" indeterminate></vaadin-progress-bar>
+        <vaadin-message-list .items="${this._uploadingQueue}"></vaadin-message-list>
+      `;
+    }
+  }
+
+  private _renderMavenCentral() {
+
+    let merged = [];
+    if (this._uploadedQueue && this._uploadedQueue.length > 0) {
+      merged = merged.concat(this._uploadedQueue);
+    }
+    if (this._closedQueue && this._closedQueue.length > 0) {
+      merged = merged.concat(this._closedQueue);
+    }
+    if (this._releasingQueue && this._releasingQueue.length > 0) {
+      merged = merged.concat(this._releasingQueue);
+    }
+    if (this._releasedQueue && this._releasedQueue.length > 0) {
+      merged = merged.concat(this._releasedQueue);
     }
 
-    private _renderInitQueue() {
-        if (this._initQueue && this._initQueue.length > 0) {
-            return html`<vaadin-message-list .items="${this._initQueue}"></vaadin-message-list>
-            <l-dot-stream
-                size="60"
-                speed="2.5"
-                color="#66a5b1" 
-            ></l-dot-stream>`;
-        } else {
-            return html`<l-dot-stream
-                size="60"
-                speed="2.5"
-                color="#66a5b1" 
-            ></l-dot-stream> <br/>Waiting for sync
-            `;
-        }
+    return html`
+      <div class="maven-central">
+        <vaadin-message-list class="maven-central-message-box" .items="${merged}"></vaadin-message-list>
+      </div>`;
+  }
+
+  private _addToQueue(queue: any[] | null, item: any, stagemessage: string, step: number) {
+    let mle = this._toMessageListEntry(item, stagemessage, step);
+    if (queue && queue.length > 0) {
+      return [...queue, mle];
+    } else {
+      return [mle];
+    }
+  }
+
+  private _addMultipleToQueue(queue: any[] | null, items: any[], stagemessage: string, step: number) {
+    let mles = items.map(item => this._toMessageListEntry(item, stagemessage, step));
+    if (queue && queue.length > 0) {
+      return [...queue, ...mles];
+    } else {
+      return mles;
+    }
+  }
+
+  private _removeFromQueue(queue: any[] | null, item: any) {
+    if (queue && queue.length > 0) {
+      var index = queue.findIndex(mle => {
+        return mle.time == item.groupId && mle.userName == item.artifactId + " " + item.version;
+      });
+      queue.splice(index, 1);
     }
 
-    private _renderUploading() {
-        if (this._uploadingQueue && this._uploadingQueue.length > 0) {
-            return html`
-                <vaadin-progress-bar class="progressBar" indeterminate></vaadin-progress-bar>
-                <vaadin-message-list .items="${this._uploadingQueue}"></vaadin-message-list>
-            `;
-        }
+    if (queue && queue.length == 0) {
+      return null;
+    } else {
+      return [...queue];
     }
+  }
 
-    private _renderMavenCentral() {
-        
-        let merged = [];
-        if (this._uploadedQueue && this._uploadedQueue.length > 0) {
-            merged = merged.concat(this._uploadedQueue);
-        }
-        if (this._closedQueue && this._closedQueue.length > 0) {
-            merged = merged.concat(this._closedQueue);
-        }
-        if (this._releasingQueue && this._releasingQueue.length > 0) {
-            merged = merged.concat(this._releasingQueue);
-        }
-        if (this._releasedQueue && this._releasedQueue.length > 0) {
-            merged = merged.concat(this._releasedQueue);
-        }
-        
-        return html`<div class="maven-central">
-                        <vaadin-message-list class="maven-central-message-box" .items="${merged}"></vaadin-message-list>
-                    </div>`;
-    }
-
-    private _addToQueue(queue: any[] | null, item: any, stagemessage: string, step: number) {
-        let mle = this._toMessageListEntry(item, stagemessage, step);
-        if (queue && queue.length > 0) {
-            return [...queue, mle];
-        } else {
-            return [mle];
-        }
-    }
-
-    private _addMultipleToQueue(queue: any[] | null, items: any[], stagemessage: string, step: number) {
-        let mles = items.map(item => this._toMessageListEntry(item, stagemessage, step));
-        if (queue && queue.length > 0) {
-            return [...queue, ...mles];
-        } else {
-            return mles;
-        }
-    }
-
-    private _removeFromQueue(queue: any[] | null, item: any) {
-        if (queue && queue.length > 0) {
-            var index = queue.findIndex(mle => {
-                return mle.time == item.groupId && mle.userName == item.artifactId + " " + item.version;
-            });
-            queue.splice(index, 1);
-        }
-
-        if (queue && queue.length == 0) {
-            return null;
-        } else {
-            return [...queue];
-        }
-    }
-
-    private _toMessageListEntry(item: any, stagemessage: string, step: number) {
-        return {
-            text: stagemessage + " (" + item.uploadAttempts + ")" ,
-            time: item.groupId,
-            userName: item.artifactId + " " + item.version,
-            userColorIndex: step
-        };
-    }
+  private _toMessageListEntry(item: any, stagemessage: string, step: number) {
+    return {
+      text: stagemessage + " (" + item.uploadAttempts + ")",
+      time: item.groupId,
+      userName: item.artifactId + " " + item.version,
+      userColorIndex: step
+    };
+  }
 }


### PR DESCRIPTION
The goal of this PR is to avoid thread blocking and reduce unnecessary requests to the server.

- Sync menu selected tab with url
- Add checkbox to enable live-sync (websocket)
- Remove websocket calls from home page
- I also added a fix in properties to avoid thread blocking by websocket following a solution found here https://stackoverflow.com/questions/68573438/blocking-io-thread-in-quarkus-websocket (cc @cescoffier @geoand FYI for the thread blocking, we had a lot of them in websocket stuff in the logs.):
```properties
quarkus.websocket.dispatch-to-worker=true
quarkus.scheduler.start-mode=forced
```

