### PR TITLE
Skip dependencies that start with "file"

### DIFF
--- a/src/main/java/io/mvnpm/creator/type/PomService.java
+++ b/src/main/java/io/mvnpm/creator/type/PomService.java
@@ -279,7 +279,7 @@ public class PomService {
     private void populateFromMap(List<Dependency> listToPopulate, Map<Name, String> dependencies) {
         if (dependencies != null && !dependencies.isEmpty()) {
             for (Map.Entry<Name, String> e : dependencies.entrySet()) {
-                if (e.getValue().startsWith("file")) {
+                if (e.getValue().startsWith("file:")) {
                     continue;
                 }
                 Name name = e.getKey();

--- a/src/main/java/io/mvnpm/creator/type/PomService.java
+++ b/src/main/java/io/mvnpm/creator/type/PomService.java
@@ -279,6 +279,9 @@ public class PomService {
     private void populateFromMap(List<Dependency> listToPopulate, Map<Name, String> dependencies) {
         if (dependencies != null && !dependencies.isEmpty()) {
             for (Map.Entry<Name, String> e : dependencies.entrySet()) {
+                if (e.getValue().startsWith("file")) {
+                    continue;
+                }
                 Name name = e.getKey();
                 String version = e.getValue();
                 listToPopulate.add(toDependency(name, version));


### PR DESCRIPTION
For some reason tailwind 3.2.5 has a file based dependency, skipping that when that happens

fixes: #36791
