### PR TITLE
Fixes and Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ nbactions.xml
 
 # Quarkus
 .quarkus
+
+# CacheBro
+.cachebro/

--- a/src/main/java/io/mvnpm/creator/PackageFileLocator.java
+++ b/src/main/java/io/mvnpm/creator/PackageFileLocator.java
@@ -75,21 +75,29 @@ public class PackageFileLocator {
         return Paths.get(localUserDirectory.orElse(Constants.CACHE_DIR)).resolve(localM2Directory);
     }
 
+    public Path getMetadataDir() {
+        return Paths.get(localUserDirectory.orElse(Constants.CACHE_DIR)).resolve("metadata");
+    }
+
     public Path getArtifactRoot(Name name) {
         return getGroupRoot(name.mvnPath).resolve(
                 Paths.get(name.mvnArtifactId));
     }
 
+    private Path getMetadataArtifactRoot(Name name) {
+        return getMetadataDir().resolve(name.mvnPath).resolve(name.mvnArtifactId);
+    }
+
     public Path getLocalMetadataXmlFullPath(Name name) {
-        return getArtifactRoot(name).resolve(Constants.MAVEN_METADATA_XML);
+        return getMetadataArtifactRoot(name).resolve(Constants.MAVEN_METADATA_XML);
     }
 
     public Path getLocalMetadataXmlSha1FullPath(Name name) {
-        return getArtifactRoot(name).resolve(Constants.MAVEN_METADATA_XML + Constants.DOT_SHA1);
+        return getMetadataArtifactRoot(name).resolve(Constants.MAVEN_METADATA_XML + Constants.DOT_SHA1);
     }
 
     public Path getLocalMetadataXmlMd5FullPath(Name name) {
-        return getArtifactRoot(name).resolve(Constants.MAVEN_METADATA_XML + Constants.DOT_MD5);
+        return getMetadataArtifactRoot(name).resolve(Constants.MAVEN_METADATA_XML + Constants.DOT_MD5);
     }
 
     public Path getLocalDirectory(Name name, String version) {

--- a/src/main/java/io/mvnpm/mavencentral/sync/CentralSyncCleanup.java
+++ b/src/main/java/io/mvnpm/mavencentral/sync/CentralSyncCleanup.java
@@ -1,16 +1,30 @@
 package io.mvnpm.mavencentral.sync;
 
+import static io.quarkus.scheduler.Scheduled.ConcurrentExecution.SKIP;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
 import org.apache.commons.io.FileUtils;
 
-import io.mvnpm.creator.*;
+import io.mvnpm.creator.PackageFileLocator;
 import io.quarkus.logging.Log;
+import io.quarkus.scheduler.Scheduled;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.common.annotation.Blocking;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
 
 /**
  * Once released in central we can clean up locally and drop the repo in oss
@@ -23,6 +37,16 @@ public class CentralSyncCleanup {
     @Inject
     PackageFileLocator packageFileLocator;
 
+    @Inject
+    CentralSyncItemService centralSyncItemService;
+
+    void onStart(@Observes io.quarkus.runtime.StartupEvent ev) {
+        Uni.createFrom().voidItem()
+                .onItem().delayIt().by(Duration.ofMinutes(5))
+                .emitOn(Infrastructure.getDefaultWorkerPool())
+                .subscribe().with(v -> weeklyCleanup());
+    }
+
     @ConsumeEvent("central-sync-item-stage-change")
     @Blocking
     public void artifactReleased(CentralSyncItem centralSyncItem) {
@@ -32,5 +56,72 @@ public class CentralSyncCleanup {
                     centralSyncItem.version);
             FileUtils.deleteQuietly(dir.toFile());
         }
+    }
+
+    /**
+     * Weekly cleanup of version directories that are no longer needed.
+     * Walks the repository tree (which only contains artifact files, not metadata)
+     * and deletes version directories that are not actively being synced.
+     */
+    @Scheduled(cron = "0 0 4 ? * SUN", concurrentExecution = SKIP)
+    @Blocking
+    public void weeklyCleanup() {
+        Log.info("Starting weekly artifact cache cleanup...");
+        Path mvnpmRoot = packageFileLocator.getMvnpmRoot();
+        if (!Files.isDirectory(mvnpmRoot)) {
+            Log.info("Cache directory does not exist, skipping cleanup");
+            return;
+        }
+
+        Set<Path> toDelete = new HashSet<>();
+        try {
+            Files.walkFileTree(mvnpmRoot, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    String name = file.getFileName().toString();
+                    if (name.endsWith(".jar") || name.endsWith(".pom") || name.endsWith(".tgz")) {
+                        Path versionDir = file.getParent();
+                        if (!toDelete.contains(versionDir)) {
+                            if (canDelete(versionDir)) {
+                                toDelete.add(versionDir);
+                            }
+                        }
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            Log.warnf("Error walking cache directory: %s", e.getMessage());
+        }
+
+        for (Path dir : toDelete) {
+            Log.infof("Cleaning up: %s", dir);
+            FileUtils.deleteQuietly(dir.toFile());
+        }
+        Log.infof("Weekly cleanup complete: deleted %d version directories", toDelete.size());
+    }
+
+    private boolean canDelete(Path versionDir) {
+        Path mvnpmRoot = packageFileLocator.getMvnpmRoot();
+        Path relativePath = mvnpmRoot.relativize(versionDir);
+        int nameCount = relativePath.getNameCount();
+        if (nameCount < 2) {
+            return false;
+        }
+
+        String version = relativePath.getFileName().toString();
+        String artifactId = relativePath.getParent().getFileName().toString();
+        StringBuilder groupId = new StringBuilder("org.mvnpm");
+        for (int i = 0; i < nameCount - 2; i++) {
+            groupId.append('.').append(relativePath.getName(i));
+        }
+
+        CentralSyncItem item = centralSyncItemService.find(groupId.toString(), artifactId, version);
+        return item == null || item.alreadyReleased();
     }
 }

--- a/src/main/resources/META-INF/resources/llms.txt
+++ b/src/main/resources/META-INF/resources/llms.txt
@@ -1,0 +1,45 @@
+# mvnpm
+
+> mvnpm is the bridge between NPM and Maven Central. It lets Java developers use NPM packages as standard Maven or Gradle dependencies directly from Maven Central.
+
+## How it works
+
+Most popular NPM packages are already synced to Maven Central and can be used directly like any other Maven dependency. When a new version is published on NPM, mvnpm automatically detects it and syncs it to Maven Central.
+
+If a package is not yet on Maven Central, you can trigger a sync from the mvnpm website. For new projects with many unsynced dependencies, the mvnpm repository can be configured as a fallback to fetch and sync packages on the fly.
+
+## Usage
+
+### Maven
+```xml
+<dependency>
+    <groupId>org.mvnpm</groupId>
+    <artifactId>{package-name}</artifactId>
+    <version>{package-version}</version>
+</dependency>
+```
+
+### Gradle
+```groovy
+implementation 'org.mvnpm:{package-name}:{package-version}'
+```
+
+### Scoped packages
+Scoped NPM packages use `org.mvnpm.at.{namespace}` as the groupId.
+For example, `@hotwired/stimulus` becomes `org.mvnpm.at.hotwired:stimulus`.
+
+## Key features
+- Use any NPM package as a Maven or Gradle dependency from Maven Central
+- Automatic sync of new NPM versions to Maven Central
+- On-demand sync for unsynced packages via the mvnpm website
+- Fallback repository for new projects with many unsynced dependencies
+- NPM semver ranges converted to Maven version range syntax
+- Dependency locking via mvnpm locker plugin (Maven) or native Gradle locking
+
+## Links
+- Website: https://mvnpm.org
+- Documentation: https://mvnpm.org/doc
+- Source Code: https://github.com/mvnpm/mvnpm
+- mvnpm Locker Plugin: https://github.com/mvnpm/locker
+- Import Map Support: https://github.com/mvnpm/importmap
+- esbuild-java: https://github.com/mvnpm/esbuild-java

--- a/src/main/resources/META-INF/resources/robots.txt
+++ b/src/main/resources/META-INF/resources/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+Disallow: /maven2/
+Disallow: /api/
+Disallow: /q/
+
+Sitemap: https://mvnpm.org/sitemap.xml

--- a/src/main/resources/META-INF/resources/sitemap.xml
+++ b/src/main/resources/META-INF/resources/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://mvnpm.org/</loc>
+  </url>
+  <url>
+    <loc>https://mvnpm.org/doc</loc>
+  </url>
+  <url>
+    <loc>https://mvnpm.org/releases</loc>
+  </url>
+  <url>
+    <loc>https://mvnpm.org/composites</loc>
+  </url>
+</urlset>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,6 @@ copyright.year=2025
 quarkus.banner.path=asciiart.txt
 quarkus.test.integration-test-profile=test
 
-quarkus.web-bundler.dependencies.node-modules=node_modules
 
 quarkus.rest-client.npm-registry.url=https://registry.npmjs.org
 quarkus.rest-client.npm-registry.verify-host=false
@@ -77,7 +76,7 @@ quarkus.mailer.auth-methods=DIGEST-MD5 CRAM-SHA256 CRAM-SHA1 CRAM-MD5 PLAIN LOGI
 quarkus.mailer.from=mvnpm.notification@gmail.com
 quarkus.mailer.host=smtp.gmail.com
 quarkus.mailer.port=465
-quarkus.mailer.ssl=true
+quarkus.mailer.tls=true
 quarkus.mailer.username=mvnpm.notification@gmail.com
 
 quarkus.mailer.mock=true
@@ -88,10 +87,10 @@ quarkus.mailer.mock=true
 %prod.quarkus.datasource.password=mvnpm
 %prod.quarkus.datasource.username=mvnpm
 
-%prod.quarkus.hibernate-orm.database.generation=update
+%prod.quarkus.hibernate-orm.schema-management.strategy=update
 
-%dev.quarkus.hibernate-orm.database.generation=drop-and-create
-%test.quarkus.hibernate-orm.database.generation=drop-and-create
+%dev.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+%test.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 mvnpm.metadata-timeout.minutes=1440
 %dev.mvnpm.metadata-timeout.minutes=1

--- a/src/main/resources/web/app/mvnpm-doc.ts
+++ b/src/main/resources/web/app/mvnpm-doc.ts
@@ -38,7 +38,13 @@ export class MvnpmDoc extends LitElement {
             width: 100%;
         }
 
-        h3 {
+        h1 {
+            margin-top: 0;
+            font-weight: 700;
+            font-size: 1.6em;
+        }
+
+        h2 {
             margin-top: 0;
             font-weight: 600;
         }
@@ -121,8 +127,9 @@ export class MvnpmDoc extends LitElement {
 
     render() {
         return html`
+            <h1>Getting Started with mvnpm</h1>
             <section>
-                <h3>Add an NPM dependency</h3>
+                <h2>Add an NPM dependency</h2>
                 <p><b>mvnpm</b> lets you consume <a href="https://www.npmjs.com/" target="_blank">NPM Registry</a> packages as dependencies directly from a Maven or Gradle project.</p>
                 <p><strong>Maven</strong></p>
                 <qui-code-block mode="xml" content="${this._dep}"></qui-code-block>
@@ -134,7 +141,7 @@ export class MvnpmDoc extends LitElement {
                 </p>
             </section>
             <section>
-                <h3>Ways to consume</h3>
+                <h2>Ways to consume</h2>
                 <ul>
                     <li>Packaged and served with the <a href="https://docs.quarkiverse.io/quarkus-web-bundler/dev/index.html" target="_blank">Quarkus Web Bundler extension</a> using scope "provided"</li>
                     <li>Directly served by Quarkus with scope "runtime"</li>
@@ -143,8 +150,8 @@ export class MvnpmDoc extends LitElement {
                 </ul>
             </section>
             <section>
-                <h3>How it works</h3>
-                <img class="how" src="/static/how-does-mvnpm-work.png"/>
+                <h2>How it works</h2>
+                <img class="how" src="/static/how-does-mvnpm-work.png" alt="Diagram showing how mvnpm converts NPM packages to Maven artifacts and syncs them to Maven Central"/>
                 <ol>
                     <li>Your Maven/Gradle build requests an NPM package from Maven Central.</li>
                     <li>If the package doesn't exist on Central yet, the build falls through to the mvnpm repository (if configured as a fallback).</li>
@@ -155,7 +162,7 @@ export class MvnpmDoc extends LitElement {
                 </ol>
             </section>
             <section>
-                <h3>Syncing a missing package</h3>
+                <h2>Syncing a missing package</h2>
                 <p>Most popular packages are already synced to Maven Central and can be used directly. Check the "Maven Central" badge on the <a href="/">Browse page</a> to see if a package version is available.</p>
                 <p>If it's not synced yet:</p>
                 <ul>
@@ -165,17 +172,17 @@ export class MvnpmDoc extends LitElement {
                 <p><strong>Use Maven Central for production builds.</strong> The fallback repository is for development and initial sync only.</p>
             </section>
             <section>
-                <h3 id="configure-fallback-repo">Configuring the fallback repository</h3>
+                <h2 id="configure-fallback-repo">Configuring the fallback repository</h2>
                 <p>The mvnpm Maven repository is a facade on top of the <a href="https://www.npmjs.com/" target="_blank">NPM Registry</a>. It's useful when starting a project or updating versions with many unsynced packages.</p>
                 <p>Add the following to your <span class="url">~/.m2/settings.xml</span>:</p>
                 <qui-code-block mode="xml" content="${this._settings}"></qui-code-block>
             </section>
             <section>
-                <h3>Version updates</h3>
+                <h2>Version updates</h2>
                 <p>mvnpm continuously monitors the NPM Registry for previously synchronized packages. When a new version is detected, it's automatically synced to Maven Central. Tools like Dependabot and Renovate will be able to propose version updates in your pull requests.</p>
             </section>
             <section>
-                <h3 id="how-to-lock-dependencies-">Locking dependencies</h3>
+                <h2 id="how-to-lock-dependencies-">Locking dependencies</h2>
                 <p><strong>Maven</strong></p>
                 <p>The <a href="https://github.com/mvnpm/locker" target="_blank">mvnpm locker Maven Plugin</a> creates a version locker profile for your <code>org.mvnpm</code> and <code>org.webjars</code> dependencies, similar to <code>package-lock.json</code> or <code>yarn.lock</code>.</p>
                 <p>This is essential because NPM dependencies use version ranges. Without locking, your builds may pull different versions between runs. The locker also reduces the number of files Maven needs to download (better for reproducibility and CI).</p>

--- a/src/main/resources/web/app/mvnpm-event-log.ts
+++ b/src/main/resources/web/app/mvnpm-event-log.ts
@@ -138,12 +138,12 @@ export class MvnpmEventLog extends LitElement {
 
     return html`
       <div class="line">
-        <span style="color: grey">${formattedTime}</span>
-        <span style="color: lightblue">${entry.groupId}</span>
-        <span style="color: lightyellow">${entry.artifactId}</span>
-        <span style="color: lightpink">${entry.version}</span>
-        <span style="color: lightgrey">[${entry.stage}]</span>
-        <span style="color: ${entry.color}">${entry.message}</span>
+        <span style="color: var(--mvnpm-log-time, grey)">${formattedTime}</span>
+        <span style="color: var(--mvnpm-log-group, lightblue)">${entry.groupId}</span>
+        <span style="color: var(--mvnpm-log-artifact, lightyellow)">${entry.artifactId}</span>
+        <span style="color: var(--mvnpm-log-version, lightpink)">${entry.version}</span>
+        <span style="color: var(--mvnpm-log-stage, lightgrey)">[${entry.stage}]</span>
+        <span style="color: var(--mvnpm-log-${entry.color}, ${entry.color})">${entry.message}</span>
       </div>`;
   }
 

--- a/src/main/resources/web/app/mvnpm-home.ts
+++ b/src/main/resources/web/app/mvnpm-home.ts
@@ -136,18 +136,21 @@ export class MvnpmHome extends LitElement {
       }
 
       .how-step-icon.npm {
-          border-color: #CB3837;
-          color: #CB3837;
+          border-color: var(--mvnpm-text-primary, #18181B);
+          color: var(--mvnpm-text-primary, #18181B);
       }
 
       .how-step-icon.mvnpm {
-          border-color: var(--mvnpm-amber, #F59E0B);
-          color: var(--mvnpm-amber, #F59E0B);
+          border-image: linear-gradient(135deg, var(--mvnpm-amber, #F59E0B), var(--mvnpm-indigo, #6366F1)) 1;
+          background: linear-gradient(135deg, var(--mvnpm-amber, #F59E0B), var(--mvnpm-indigo, #6366F1));
+          -webkit-background-clip: text;
+          -webkit-text-fill-color: transparent;
+          background-clip: text;
       }
 
       .how-step-icon.maven {
-          border-color: var(--mvnpm-indigo, #6366F1);
-          color: var(--mvnpm-indigo, #6366F1);
+          border-color: var(--mvnpm-amber, #F59E0B);
+          color: var(--mvnpm-amber, #F59E0B);
       }
 
       .how-step-label {
@@ -155,6 +158,8 @@ export class MvnpmHome extends LitElement {
           font-weight: 600;
           color: var(--mvnpm-text-secondary, var(--lumo-secondary-text-color));
       }
+
+
 
       .how-step-desc {
           font-size: 0.75rem;
@@ -687,7 +692,7 @@ export class MvnpmHome extends LitElement {
         </div>
         <div class="how-arrow">&#10230;</div>
         <div class="how-step">
-          <div class="how-step-icon mvnpm">mv</div>
+          <div class="how-step-icon mvnpm">{/&gt;</div>
           <div class="how-step-label">mvnpm</div>
           <div class="how-step-desc">Converts to JARs, POMs &amp; signs</div>
         </div>
@@ -990,12 +995,12 @@ export class MvnpmHome extends LitElement {
 
     return html`
       <div class="gaveventlogline">
-        <span style="color: grey">${formattedTime}</span>
-        <span style="color: lightblue">${entry.groupId}</span>
-        <span style="color: lightyellow">${entry.artifactId}</span>
-        <span style="color: lightpink">${entry.version}</span>
-        <span style="color: lightgrey">[${entry.stage}]</span>
-        <span style="color: ${entry.color}">${entry.message}</span>
+        <span style="color: var(--mvnpm-log-time, grey)">${formattedTime}</span>
+        <span style="color: var(--mvnpm-log-group, lightblue)">${entry.groupId}</span>
+        <span style="color: var(--mvnpm-log-artifact, lightyellow)">${entry.artifactId}</span>
+        <span style="color: var(--mvnpm-log-version, lightpink)">${entry.version}</span>
+        <span style="color: var(--mvnpm-log-stage, lightgrey)">[${entry.stage}]</span>
+        <span style="color: var(--mvnpm-log-${entry.color}, ${entry.color})">${entry.message}</span>
       </div>`;
   }
 

--- a/src/main/resources/web/app/mvnpm.css
+++ b/src/main/resources/web/app/mvnpm.css
@@ -44,6 +44,15 @@ html[data-theme="dark"], html:not([data-theme]) {
 
     --mvnpm-code-bg: #151722;
 
+    /* Log entry colors */
+    --mvnpm-log-time: grey;
+    --mvnpm-log-group: lightblue;
+    --mvnpm-log-artifact: lightyellow;
+    --mvnpm-log-version: lightpink;
+    --mvnpm-log-stage: lightgrey;
+    --mvnpm-log-lightgreen: lightgreen;
+    --mvnpm-log-red: red;
+
     /* Lumo overrides */
     --lumo-clickable-cursor: pointer;
     --lumo-base-color: var(--mvnpm-bg-primary);
@@ -95,12 +104,21 @@ html[data-theme="light"] {
     --mvnpm-border-subtle: #F0F0F2;
 
     --mvnpm-text-primary: #18181B;
-    --mvnpm-text-secondary: #52525B;
-    --mvnpm-text-tertiary: #A1A1AA;
+    --mvnpm-text-secondary: #3F3F46;
+    --mvnpm-text-tertiary: #71717A;
     --mvnpm-text-link: #4F46E5;
     --mvnpm-text-link-hover: #6366F1;
 
     --mvnpm-code-bg: #F4F4F5;
+
+    /* Log entry colors */
+    --mvnpm-log-time: #71717A;
+    --mvnpm-log-group: #2563EB;
+    --mvnpm-log-artifact: #A16207;
+    --mvnpm-log-version: #DB2777;
+    --mvnpm-log-stage: #52525B;
+    --mvnpm-log-lightgreen: #16A34A;
+    --mvnpm-log-red: #DC2626;
 
     /* Lumo overrides */
     --lumo-clickable-cursor: pointer;
@@ -225,6 +243,7 @@ main {
     justify-content: flex-start;
     overflow-x: hidden;
     overflow-y: auto;
+    padding-top: 16px;
 }
 
 /* --- Footer --- */

--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<html data-theme="dark">
+<html lang="en" data-theme="dark">
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
-        <link rel="shortcut icon" type="image/png" href="/static/ico.png">
         {#bundle /}
         {#let title="mvnpm - Use NPM packages as Maven/Gradle dependencies"}
         {#let description="Seamlessly integrate NPM packages into Java through Maven and Gradle dependencies. The bridge between NPM and Maven Central."}
@@ -40,13 +39,60 @@
         <script type="application/ld+json">
             {
                 "@context": "https://schema.org",
-                "@type": "SoftwareApplication",
-                "name": "mvnpm",
-                "description": "{description}",
-                "url": "https://mvnpm.org/",
-                "image": "https://mvnpm.org/static/logo.svg",
-                "applicationCategory": "DeveloperTool",
-                "operatingSystem": "Cross-platform"
+                "@graph": [
+                    {
+                        "@type": "Organization",
+                        "@id": "https://mvnpm.org/#organization",
+                        "name": "mvnpm",
+                        "url": "https://mvnpm.org/",
+                        "logo": "https://mvnpm.org/static/logo.svg",
+                        "sameAs": [
+                            "https://github.com/mvnpm/mvnpm"
+                        ],
+                        "parentOrganization": {
+                            "@type": "Organization",
+                            "name": "Commonhaus Foundation",
+                            "url": "https://www.commonhaus.org"
+                        }
+                    },
+                    {
+                        "@type": "WebSite",
+                        "@id": "https://mvnpm.org/#website",
+                        "name": "mvnpm",
+                        "url": "https://mvnpm.org/",
+                        "description": "{description}",
+                        "publisher": {
+                            "@id": "https://mvnpm.org/#organization"
+                        },
+                        "potentialAction": {
+                            "@type": "SearchAction",
+                            "target": {
+                                "@type": "EntryPoint",
+                                "urlTemplate": "https://mvnpm.org/search/\{search_term_string}"
+                            },
+                            "query-input": "required name=search_term_string"
+                        }
+                    },
+                    {
+                        "@type": "SoftwareApplication",
+                        "@id": "https://mvnpm.org/#software",
+                        "name": "mvnpm",
+                        "description": "{description}",
+                        "url": "https://mvnpm.org/",
+                        "image": "https://mvnpm.org/static/logo.svg",
+                        "applicationCategory": "DeveloperApplication",
+                        "operatingSystem": "Cross-platform",
+                        "offers": {
+                            "@type": "Offer",
+                            "price": "0",
+                            "priceCurrency": "USD"
+                        },
+                        "codeRepository": "https://github.com/mvnpm/mvnpm",
+                        "author": {
+                            "@id": "https://mvnpm.org/#organization"
+                        }
+                    }
+                ]
             }
         </script>
 
@@ -84,7 +130,7 @@
 
         <footer>
             <div class="copyright">
-                <div>Copyright &copy; {config:['copyright.year']} <a href="https://www.commonhaus.org">mvnpm.io</a> | v{config:['quarkus.application.version']}</div>
+                <div>Copyright &copy; {config:['copyright.year']} <a href="https://www.commonhaus.org">mvnpm</a> | v{config:['quarkus.application.version']}</div>
                 <div class="smalltext">For details on our trademarks, please visit our <a href="https://www.commonhaus.org/policies/trademark-policy/">Trademark Policy</a> and <a href="https://www.commonhaus.org/trademarks/">Trademark List</a>.</div>
             </div>
             <a href="https://www.commonhaus.org" target="_blank">

--- a/src/main/resources/web/static/favicon.svg
+++ b/src/main/resources/web/static/favicon.svg
@@ -5,15 +5,5 @@
       <stop offset="100%" stop-color="#6366F1"/>
     </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#0F1117"/>
-  <!-- { -->
-  <path d="M16 18 Q10 18 10 24 L10 28 Q10 32 6 32 Q10 32 10 36 L10 40 Q10 46 16 46" stroke="url(#g)" stroke-width="3.5" fill="none" stroke-linecap="round"/>
-  <!-- } -->
-  <path d="M28 18 Q34 18 34 24 L34 28 Q34 32 38 32 Q34 32 34 36 L34 40 Q34 46 28 46" stroke="url(#g)" stroke-width="3.5" fill="none" stroke-linecap="round"/>
-  <!-- < > -->
-  <polyline points="50,22 42,32 50,42" stroke="url(#g)" stroke-width="3.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-  <polyline points="54,22 62,32 54,42" stroke="url(#g)" stroke-width="3.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-  <!-- Arrow -->
-  <line x1="36" y1="32" x2="44" y2="32" stroke="url(#g)" stroke-width="2.5" stroke-linecap="round"/>
-  <polyline points="41,29 44,32 41,35" stroke="url(#g)" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="32" y="54" font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="56" font-weight="700" fill="url(#g)" text-anchor="middle">{/&gt;</text>
 </svg>

--- a/src/main/resources/web/static/logo-reversed.svg
+++ b/src/main/resources/web/static/logo-reversed.svg
@@ -1,21 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 120" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 120" fill="none">
   <defs>
     <linearGradient id="bridge" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0%" stop-color="#F59E0B"/>
       <stop offset="100%" stop-color="#6366F1"/>
     </linearGradient>
   </defs>
-  <!-- Bridge icon: { } connected to < > -->
-  <g transform="translate(0, 18)">
-    <path d="M12 20 Q4 20 4 28 L4 38 Q4 44 0 44 Q4 44 4 50 L4 60 Q4 68 12 68" stroke="url(#bridge)" stroke-width="3.5" fill="none" stroke-linecap="round"/>
-    <path d="M30 20 Q38 20 38 28 L38 38 Q38 44 42 44 Q38 44 38 50 L38 60 Q38 68 30 68" stroke="url(#bridge)" stroke-width="3.5" fill="none" stroke-linecap="round"/>
-    <line x1="46" y1="44" x2="68" y2="44" stroke="url(#bridge)" stroke-width="3" stroke-linecap="round"/>
-    <polyline points="62,38 68,44 62,50" stroke="url(#bridge)" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-    <polyline points="88,28 76,44 88,60" stroke="url(#bridge)" stroke-width="3.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-    <polyline points="92,28 104,44 92,60" stroke="url(#bridge)" stroke-width="3.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-  </g>
+  <!-- {/> prefix -->
+  <text x="10" y="82" font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', Consolas, monospace" font-size="64" font-weight="700" fill="url(#bridge)">{/&gt;</text>
   <!-- Wordmark - white text for dark backgrounds -->
-  <text x="120" y="80" font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', Consolas, monospace" font-size="64" font-weight="700" letter-spacing="-1">
+  <text x="175" y="82" font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', Consolas, monospace" font-size="64" font-weight="700" letter-spacing="-1">
     <tspan fill="#F0F0F0">mvn</tspan><tspan fill="#F59E0B">pm</tspan>
   </text>
 </svg>

--- a/src/main/resources/web/static/logo.svg
+++ b/src/main/resources/web/static/logo.svg
@@ -1,26 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 120" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 120" fill="none">
   <defs>
     <linearGradient id="bridge" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0%" stop-color="#F59E0B"/>
       <stop offset="100%" stop-color="#6366F1"/>
     </linearGradient>
   </defs>
-  <!-- Bridge icon: { } connected to < > -->
-  <g transform="translate(0, 18)">
-    <!-- Left bracket { -->
-    <path d="M12 20 Q4 20 4 28 L4 38 Q4 44 0 44 Q4 44 4 50 L4 60 Q4 68 12 68" stroke="url(#bridge)" stroke-width="3.5" fill="none" stroke-linecap="round"/>
-    <!-- Right bracket } -->
-    <path d="M30 20 Q38 20 38 28 L38 38 Q38 44 42 44 Q38 44 38 50 L38 60 Q38 68 30 68" stroke="url(#bridge)" stroke-width="3.5" fill="none" stroke-linecap="round"/>
-    <!-- Arrow bridge -->
-    <line x1="46" y1="44" x2="68" y2="44" stroke="url(#bridge)" stroke-width="3" stroke-linecap="round"/>
-    <polyline points="62,38 68,44 62,50" stroke="url(#bridge)" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-    <!-- Left angle < -->
-    <polyline points="88,28 76,44 88,60" stroke="url(#bridge)" stroke-width="3.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-    <!-- Right angle > -->
-    <polyline points="92,28 104,44 92,60" stroke="url(#bridge)" stroke-width="3.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-  </g>
+  <!-- {/> prefix -->
+  <text x="10" y="82" font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', Consolas, monospace" font-size="64" font-weight="700" fill="url(#bridge)">{/&gt;</text>
   <!-- Wordmark -->
-  <text x="120" y="80" font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', Consolas, monospace" font-size="64" font-weight="700" letter-spacing="-1">
+  <text x="175" y="82" font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', Consolas, monospace" font-size="64" font-weight="700" letter-spacing="-1">
     <tspan fill="currentColor">mvn</tspan><tspan fill="#F59E0B">pm</tspan>
   </text>
 </svg>


### PR DESCRIPTION
### UI
- Fix log panel text colors in light mode using theme-aware CSS variables
- Update both mvnpm-home and mvnpm-event-log to use log color variables
- Map server-side message colors (lightgreen, red) to themed variables
- Darken secondary/tertiary text in light mode for better readability
- Replace bridge icon with {/> textual logo in SVGs and favicon
- Update how-it-works cards: black npm, gradient mvnpm, orange maven
- Use transparent background for favicon SVG
- Remove PNG favicon fallback
- Add top padding under header
- Add .cachebro to .gitignore

### Separate metadata from repository cache and add weekly cleanup
- Move metadata files (maven-metadata.xml) to a dedicated metadata/
  directory, separate from the repository/ artifact cache
- Add weekly scheduled cleanup (Sundays 4am) that walks the repository
  tree and deletes version directories not actively being synced
- Fixes disk space accumulation from artifacts that missed event-based
  cleanup (e.g. due to restarts or missed RELEASED events)
