### PR TITLE
Fix cleanup to only delete RELEASED items and add GAV logging

### DIFF
--- a/src/main/java/io/mvnpm/mavencentral/sync/CentralSyncCleanup.java
+++ b/src/main/java/io/mvnpm/mavencentral/sync/CentralSyncCleanup.java
@@ -121,7 +121,16 @@ public class CentralSyncCleanup {
             groupId.append('.').append(relativePath.getName(i));
         }
 
+        String gav = groupId + ":" + artifactId + ":" + version;
         CentralSyncItem item = centralSyncItemService.find(groupId.toString(), artifactId, version);
-        return item == null || item.alreadyReleased();
+        if (item == null) {
+            Log.warnf("No sync item found for %s, skipping", gav);
+            return false;
+        }
+        if (item.alreadyReleased()) {
+            Log.infof("Deleting %s (stage: RELEASED)", gav);
+            return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
- Only delete version directories for items confirmed RELEASED in DB
- Log warning for items not found in DB instead of deleting
- Log GAV for each deleted directory for traceability
- Fix deprecated config keys (hibernate-orm, mailer)