### PR TITLE
Upgrade Quarkus to 3.32.4 and fix Vaadin 25 theming + search UX

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,19 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-wrapperVersion=3.3.2
+wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip
+distributionSha256Sum=305773a68d6ddfd413df58c82b3f8050e89778e777f3a745c8e5b8cbea4018ef

--- a/mvnw
+++ b/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.3.2
+# Apache Maven Wrapper startup batch script, version 3.3.4
 #
 # Optional ENV vars
 # -----------------
@@ -105,14 +105,17 @@ trim() {
   printf "%s" "${1}" | tr -d '[:space:]'
 }
 
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
 # parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
 while IFS="=" read -r key value; do
   case "${key-}" in
   distributionUrl) distributionUrl=$(trim "${value-}") ;;
   distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
   esac
-done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
-[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
 
 case "${distributionUrl##*/}" in
 maven-mvnd-*bin.*)
@@ -130,7 +133,7 @@ maven-mvnd-*bin.*)
   distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
   ;;
 maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
-*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
 esac
 
 # apply MVNW_REPOURL and calculate MAVEN_HOME
@@ -227,7 +230,7 @@ if [ -n "${distributionSha256Sum-}" ]; then
     echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
     exit 1
   elif command -v sha256sum >/dev/null; then
-    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
       distributionSha256Result=true
     fi
   elif command -v shasum >/dev/null; then
@@ -252,8 +255,41 @@ if command -v unzip >/dev/null; then
 else
   tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
 fi
-printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
-mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
 
 clean || :
 exec_maven "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.27.1</quarkus.platform.version>
+    <quarkus.platform.version>3.32.4</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
@@ -64,17 +64,8 @@
     
     <pgpainless.version>1.5.5</pgpainless.version>
     <!-- UI Libs -->
-    <quarkus-web-bundler.version>2.1.0</quarkus-web-bundler.version>
+    <quarkus-web-bundler.version>2.2.1</quarkus-web-bundler.version>
     <quarkus-roq-frontmatter.version>2.0.5</quarkus-roq-frontmatter.version>
-    <lit.version>3.3.1</lit.version>
-    <vaadin.version>24.8.3</vaadin.version>
-    <ldrs.version>1.1.7</ldrs.version>
-    <vaadin-router.version>1.7.5</vaadin-router.version>
-    <codeblock.version>1.1.1</codeblock.version>
-    <compare-versions.version>6.1.1</compare-versions.version>
-    <marked.version>16.0.0</marked.version>
-    <card.version>1.0.2</card.version>
-    <badge.version>1.0.4</badge.version>
     <!-- Testing-->
     <playwright.version>0.0.1</playwright.version>
     <esbuild-java.version>2.1.0</esbuild-java.version>
@@ -219,35 +210,30 @@
     <dependency>
         <groupId>org.mvnpm</groupId>
         <artifactId>lit</artifactId>
-        <version>${lit.version}</version>
         <scope>provided</scope>
     </dependency>
     <!-- Vaadin Web components -->
     <dependency>
       <groupId>org.mvnpm.at.mvnpm</groupId>
       <artifactId>vaadin-webcomponents</artifactId>
-      <version>${vaadin.version}</version>
       <scope>provided</scope>
     </dependency>
     <!-- Loaders -->
     <dependency>
 	<groupId>org.mvnpm</groupId>
 	<artifactId>ldrs</artifactId>
-	<version>${ldrs.version}</version>
 	<scope>provided</scope>
     </dependency>
     <!-- Router -->
     <dependency>
       <groupId>org.mvnpm.at.vaadin</groupId>
       <artifactId>router</artifactId>
-      <version>${vaadin-router.version}</version>
       <scope>provided</scope>
     </dependency>
     <!-- Codeblock -->
     <dependency>
 	<groupId>org.mvnpm.at.qomponent</groupId>
 	<artifactId>qui-code-block</artifactId>
-	<version>${codeblock.version}</version>
 	<scope>provided</scope>
     </dependency>
     <!-- Syntax highlighting for doc pages -->
@@ -261,39 +247,35 @@
     <dependency>
       <groupId>org.mvnpm</groupId>
       <artifactId>compare-versions</artifactId>
-      <version>${compare-versions.version}</version>
       <scope>provided</scope>
     </dependency>
     <!-- To render Markdown -->
     <dependency>
 	<groupId>org.mvnpm</groupId>
 	<artifactId>marked</artifactId>
-	<version>${marked.version}</version>
 	<scope>provided</scope>
     </dependency>
     <!-- Cards for display -->
     <dependency>
 	<groupId>org.mvnpm.at.qomponent</groupId>
 	<artifactId>qui-card</artifactId>
-	<version>${card.version}</version>
 	<scope>provided</scope>
     </dependency>
     <!-- Badges for display -->
     <dependency>
 	<groupId>org.mvnpm.at.qomponent</groupId>
 	<artifactId>qui-badge</artifactId>
-	<version>${badge.version}</version>
 	<scope>provided</scope>
     </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>io.quarkiverse.roq</groupId>
       <artifactId>quarkus-roq-plugin-sitemap</artifactId>
-      <version>1.10.3</version>
+      <version>2.0.5</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/resources/web/app/mvnpm-composites.ts
+++ b/src/main/resources/web/app/mvnpm-composites.ts
@@ -30,6 +30,10 @@ export class MvnpmComposites extends ThemeMixin(LitElement) {
         box-sizing: border-box;
     }
 
+    vaadin-tab[selected] {
+        --vaadin-tab-text-color: var(--lumo-primary-color);
+    }
+
     @media (min-width: 769px) {
         :host {
             overflow: hidden;

--- a/src/main/resources/web/app/mvnpm-home.ts
+++ b/src/main/resources/web/app/mvnpm-home.ts
@@ -54,6 +54,17 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
           align-items: center;
           flex-direction: column;
           column-gap: 15px;
+          padding-top: 32px;
+          padding-bottom: 8px;
+      }
+
+      vaadin-progress-bar {
+          margin: 8px;
+          height: 4px;
+      }
+
+      vaadin-tab[selected] {
+          --vaadin-tab-text-color: var(--lumo-primary-color);
       }
 
       .coordinates-name {
@@ -470,9 +481,11 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
           display: flex;
           flex-direction: column;
           gap: 12px;
-          width: 90%;
+          width: 100%;
           max-width: 900px;
-          padding: 16px 0;
+          padding: 16px 24px;
+          box-sizing: border-box;
+          align-self: center;
       }
 
       .searchResultName {
@@ -542,6 +555,9 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
               flex: 1;
               min-height: 0;
               overflow-y: auto;
+              max-width: none;
+              padding-left: max(24px, calc((100% - 852px) / 2));
+              padding-right: max(24px, calc((100% - 852px) / 2));
           }
           .fileBrowser {
               height: calc(100vh - var(--mvnpm-header-height) - var(--mvnpm-footer-height) - 180px);
@@ -576,7 +592,7 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
               font-size: 0.95rem;
           }
           .coordinates-pane {
-              padding: 0 12px;
+              padding: 16px 12px 0;
               box-sizing: border-box;
           }
           .coordinates {
@@ -629,7 +645,7 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
               margin-bottom: 12px;
           }
           .searchResults {
-              width: 95%;
+              padding: 16px 12px;
           }
           .dependencies {
               flex-direction: column;
@@ -713,6 +729,8 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
   @state()
   private _recentReleases?: any[];
 
+  private _onPopState: () => void;
+
   constructor() {
     super();
     this._clearCoordinates();
@@ -733,6 +751,30 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
   connectedCallback() {
     super.connectedCallback();
     this._fetchRecentReleases();
+    this._onPopState = this._handlePopState.bind(this);
+    window.addEventListener('popstate', this._onPopState);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('popstate', this._onPopState);
+  }
+
+  private _handlePopState() {
+    var currentPath = window.location.pathname;
+    if (currentPath.startsWith("/package/")) {
+      this._searchResults = null;
+      this._info = null;
+      this._coordinates = {};
+      this._coordinates.name = currentPath.substring(9);
+      this._showGA(this._coordinates.name);
+    } else if (currentPath.startsWith("/search/")) {
+      this._coordinates.version = null;
+      this._info = null;
+      this._search(currentPath.substring(8), false);
+    } else {
+      this._clearCoordinates();
+    }
   }
 
   private _fetchRecentReleases() {
@@ -762,7 +804,6 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
     return html`
       <div class="coordinates">
         <vaadin-text-field id="coordinates-field" label="Name (Package or Coordinates)" class="coordinates-name"
-                           @focusout="${this._findVersionsAndShowLatest}"
                            @keypress="${this._findVersionsAndShowLatest}"
                            @input="${this._coordinatesNameChanged}"
                            value="${this._coordinates.name}" clear-button-visible></vaadin-text-field>
@@ -935,8 +976,8 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
 
   _selectSearchResult(e) {
     this._coordinates.version = null;
-    this._coordinates.name = e.target.dataset.package;
-    this._showGA(this._coordinates.name);
+    this._coordinates.name = e.currentTarget.dataset.package;
+    this._showGA(this._coordinates.name, false);
   }
 
   _renderSearchKeywords(keywords) {
@@ -1192,7 +1233,7 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
     }
   }
 
-  _showGA(name) {
+  _showGA(name, fallbackToSearch = true) {
     if (name && name.length > 0) {
       let groupPath: string;
       let artifactPath: string;
@@ -1226,13 +1267,21 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
         .then(xmlDoc => new window.DOMParser().parseFromString(xmlDoc, "text/xml"))
         .then(metadata => this._inspectMetadata(metadata))
         .catch(error => {
-          this._search(name);
+          if (fallbackToSearch) {
+            this._search(name);
+          } else {
+            this._stopLoading();
+            Notification.show(name + ' is being synced, please try again shortly', {
+              position: 'top-center',
+              duration: 3000,
+            });
+          }
         });
 
     }
   }
 
-  _search(name) {
+  _search(name, updateHistory = true) {
     var searchUrl = "/api/info/search/" + name;
     fetch(searchUrl)
       .then((response) => {
@@ -1252,7 +1301,9 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
         }
       })
       .then(jsonResult => {
-        window.history.pushState({/* State */}, "", "/search/" + name);
+        if (updateHistory) {
+          window.history.pushState({/* State */}, "", "/search/" + name);
+        }
         this._coordinates.version = null;
         this._searchResults = jsonResult;
       });

--- a/src/main/resources/web/app/mvnpm.css
+++ b/src/main/resources/web/app/mvnpm.css
@@ -27,6 +27,8 @@
     /* Font */
     --mvnpm-font-mono: 'SF Mono', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', 'Consolas', monospace;
     --mvnpm-font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    --mvnpm-font-size-m: 1rem;
+    --mvnpm-line-height-m: 1.6;
 
     color-scheme: dark light;
 }
@@ -67,45 +69,62 @@ html[data-theme="dark"], html:not([data-theme]) {
     --mvnpm-log-lightgreen: lightgreen;
     --mvnpm-log-red: red;
 
-    /* Lumo overrides */
-    --lumo-clickable-cursor: pointer;
+    /* Lumo overrides (used by qui-card, qui-badge) */
     --lumo-base-color: var(--mvnpm-bg-primary);
-    --lumo-body-text-color: var(--mvnpm-text-primary);
-    --lumo-header-text-color: var(--mvnpm-text-primary);
-    --lumo-secondary-text-color: var(--mvnpm-text-secondary);
-    --lumo-tertiary-text-color: var(--mvnpm-text-tertiary);
-    --lumo-disabled-text-color: var(--mvnpm-text-tertiary);
+    --lumo-contrast: var(--mvnpm-text-primary);
+    --lumo-contrast-90pct: rgba(240, 240, 244, 0.9);
+    --lumo-contrast-80pct: rgba(240, 240, 244, 0.8);
+    --lumo-contrast-50pct: rgba(240, 240, 244, 0.5);
+    --lumo-contrast-10pct: rgba(240, 240, 244, 0.1);
+    --lumo-contrast-5pct: rgba(240, 240, 244, 0.05);
     --lumo-primary-color: var(--mvnpm-indigo-light);
     --lumo-primary-text-color: var(--mvnpm-indigo-light);
-    --lumo-primary-color-50pct: rgba(99, 102, 241, 0.5);
     --lumo-primary-color-10pct: rgba(99, 102, 241, 0.1);
     --lumo-primary-contrast-color: #ffffff;
     --lumo-error-color: var(--mvnpm-error);
     --lumo-error-text-color: #F87171;
-    --lumo-error-color-50pct: rgba(239, 68, 68, 0.5);
     --lumo-error-color-10pct: rgba(239, 68, 68, 0.1);
     --lumo-error-contrast-color: #ffffff;
     --lumo-success-color: var(--mvnpm-success);
     --lumo-success-text-color: #4ADE80;
-    --lumo-success-color-50pct: rgba(34, 197, 94, 0.5);
     --lumo-success-color-10pct: rgba(34, 197, 94, 0.1);
     --lumo-success-contrast-color: #ffffff;
     --lumo-warning-color: var(--mvnpm-warning);
     --lumo-warning-text-color: #FBBF24;
-    --lumo-warning-color-50pct: rgba(245, 158, 11, 0.5);
     --lumo-warning-color-10pct: rgba(245, 158, 11, 0.1);
     --lumo-warning-contrast-color: #ffffff;
-    --lumo-contrast: var(--mvnpm-text-primary);
-    --lumo-contrast-90pct: rgba(240, 240, 244, 0.9);
-    --lumo-contrast-80pct: rgba(240, 240, 244, 0.8);
-    --lumo-contrast-70pct: rgba(240, 240, 244, 0.7);
-    --lumo-contrast-60pct: rgba(240, 240, 244, 0.6);
-    --lumo-contrast-50pct: rgba(240, 240, 244, 0.5);
-    --lumo-contrast-40pct: rgba(240, 240, 244, 0.4);
-    --lumo-contrast-30pct: rgba(240, 240, 244, 0.3);
-    --lumo-contrast-20pct: rgba(240, 240, 244, 0.2);
-    --lumo-contrast-10pct: rgba(240, 240, 244, 0.1);
-    --lumo-contrast-5pct: rgba(240, 240, 244, 0.05);
+    --lumo-font-size-l: 1.125rem;
+    --lumo-font-size-s: 0.8125rem;
+    --lumo-font-size-xxs: 0.625rem;
+    --lumo-font-family: var(--mvnpm-font-sans);
+    --lumo-border-radius-s: var(--mvnpm-radius-sm);
+
+    /* Vaadin component overrides */
+    --vaadin-clickable-cursor: pointer;
+    --vaadin-text-color: var(--mvnpm-text-primary);
+    --vaadin-text-color-secondary: var(--mvnpm-text-secondary);
+    --vaadin-text-color-disabled: var(--mvnpm-text-tertiary);
+    --vaadin-background-color: var(--mvnpm-bg-primary);
+    --vaadin-background-container: var(--mvnpm-bg-elevated);
+    --vaadin-background-container-strong: var(--mvnpm-bg-surface);
+    --vaadin-border-color: var(--mvnpm-border);
+    --vaadin-border-color-secondary: var(--mvnpm-border-subtle);
+    --vaadin-focus-ring-color: var(--mvnpm-indigo-light);
+    --vaadin-radius-m: var(--mvnpm-radius-sm);
+    --vaadin-input-field-background: var(--mvnpm-bg-surface);
+    --vaadin-input-field-border-color: var(--mvnpm-border);
+    --vaadin-input-field-value-color: var(--mvnpm-text-primary);
+    --vaadin-input-field-label-color: var(--mvnpm-text-secondary);
+    --vaadin-input-field-placeholder-color: var(--mvnpm-text-tertiary);
+    --vaadin-input-field-helper-color: var(--mvnpm-text-tertiary);
+    --vaadin-input-field-error-color: var(--mvnpm-error);
+    --vaadin-input-field-button-text-color: var(--mvnpm-text-secondary);
+    --vaadin-input-field-required-indicator: none;
+    --vaadin-input-field-required-indicator-color: var(--mvnpm-text-tertiary);
+    --vaadin-button-text-color: var(--mvnpm-text-secondary);
+    --vaadin-button-border-color: var(--mvnpm-border);
+    --vaadin-progress-bar-background: var(--mvnpm-bg-surface);
+    --vaadin-progress-bar-value-background: var(--mvnpm-indigo-light);
 }
 
 /* --- Light Theme --- */
@@ -144,45 +163,62 @@ html[data-theme="light"] {
     --mvnpm-log-lightgreen: #16A34A;
     --mvnpm-log-red: #DC2626;
 
-    /* Lumo overrides */
-    --lumo-clickable-cursor: pointer;
+    /* Lumo overrides (used by qui-card, qui-badge) */
     --lumo-base-color: var(--mvnpm-bg-primary);
-    --lumo-body-text-color: var(--mvnpm-text-primary);
-    --lumo-header-text-color: var(--mvnpm-text-primary);
-    --lumo-secondary-text-color: var(--mvnpm-text-secondary);
-    --lumo-tertiary-text-color: var(--mvnpm-text-tertiary);
-    --lumo-disabled-text-color: var(--mvnpm-text-tertiary);
+    --lumo-contrast: var(--mvnpm-text-primary);
+    --lumo-contrast-90pct: rgba(24, 24, 27, 0.9);
+    --lumo-contrast-80pct: rgba(24, 24, 27, 0.8);
+    --lumo-contrast-50pct: rgba(24, 24, 27, 0.5);
+    --lumo-contrast-10pct: rgba(24, 24, 27, 0.1);
+    --lumo-contrast-5pct: rgba(24, 24, 27, 0.05);
     --lumo-primary-color: var(--mvnpm-indigo);
     --lumo-primary-text-color: var(--mvnpm-indigo);
-    --lumo-primary-color-50pct: rgba(99, 102, 241, 0.5);
     --lumo-primary-color-10pct: rgba(99, 102, 241, 0.1);
     --lumo-primary-contrast-color: #ffffff;
     --lumo-error-color: var(--mvnpm-error);
     --lumo-error-text-color: #DC2626;
-    --lumo-error-color-50pct: rgba(239, 68, 68, 0.5);
     --lumo-error-color-10pct: rgba(239, 68, 68, 0.1);
     --lumo-error-contrast-color: #ffffff;
     --lumo-success-color: var(--mvnpm-success);
     --lumo-success-text-color: #16A34A;
-    --lumo-success-color-50pct: rgba(34, 197, 94, 0.5);
     --lumo-success-color-10pct: rgba(34, 197, 94, 0.1);
     --lumo-success-contrast-color: #ffffff;
     --lumo-warning-color: var(--mvnpm-warning);
     --lumo-warning-text-color: #D97706;
-    --lumo-warning-color-50pct: rgba(245, 158, 11, 0.5);
     --lumo-warning-color-10pct: rgba(245, 158, 11, 0.1);
     --lumo-warning-contrast-color: #ffffff;
-    --lumo-contrast: var(--mvnpm-text-primary);
-    --lumo-contrast-90pct: rgba(24, 24, 27, 0.9);
-    --lumo-contrast-80pct: rgba(24, 24, 27, 0.8);
-    --lumo-contrast-70pct: rgba(24, 24, 27, 0.7);
-    --lumo-contrast-60pct: rgba(24, 24, 27, 0.6);
-    --lumo-contrast-50pct: rgba(24, 24, 27, 0.5);
-    --lumo-contrast-40pct: rgba(24, 24, 27, 0.4);
-    --lumo-contrast-30pct: rgba(24, 24, 27, 0.3);
-    --lumo-contrast-20pct: rgba(24, 24, 27, 0.2);
-    --lumo-contrast-10pct: rgba(24, 24, 27, 0.1);
-    --lumo-contrast-5pct: rgba(24, 24, 27, 0.05);
+    --lumo-font-size-l: 1.125rem;
+    --lumo-font-size-s: 0.8125rem;
+    --lumo-font-size-xxs: 0.625rem;
+    --lumo-font-family: var(--mvnpm-font-sans);
+    --lumo-border-radius-s: var(--mvnpm-radius-sm);
+
+    /* Vaadin component overrides */
+    --vaadin-clickable-cursor: pointer;
+    --vaadin-text-color: var(--mvnpm-text-primary);
+    --vaadin-text-color-secondary: var(--mvnpm-text-secondary);
+    --vaadin-text-color-disabled: var(--mvnpm-text-tertiary);
+    --vaadin-background-color: var(--mvnpm-bg-primary);
+    --vaadin-background-container: var(--mvnpm-bg-elevated);
+    --vaadin-background-container-strong: var(--mvnpm-bg-surface);
+    --vaadin-border-color: var(--mvnpm-border);
+    --vaadin-border-color-secondary: var(--mvnpm-border-subtle);
+    --vaadin-focus-ring-color: var(--mvnpm-indigo);
+    --vaadin-radius-m: var(--mvnpm-radius-sm);
+    --vaadin-input-field-background: var(--mvnpm-bg-surface);
+    --vaadin-input-field-border-color: var(--mvnpm-border);
+    --vaadin-input-field-value-color: var(--mvnpm-text-primary);
+    --vaadin-input-field-label-color: var(--mvnpm-text-secondary);
+    --vaadin-input-field-placeholder-color: var(--mvnpm-text-tertiary);
+    --vaadin-input-field-helper-color: var(--mvnpm-text-tertiary);
+    --vaadin-input-field-error-color: var(--mvnpm-error);
+    --vaadin-input-field-button-text-color: var(--mvnpm-text-secondary);
+    --vaadin-input-field-required-indicator: none;
+    --vaadin-input-field-required-indicator-color: var(--mvnpm-text-tertiary);
+    --vaadin-button-text-color: var(--mvnpm-text-secondary);
+    --vaadin-button-border-color: var(--mvnpm-border);
+    --vaadin-progress-bar-background: var(--mvnpm-bg-surface);
+    --vaadin-progress-bar-value-background: var(--mvnpm-indigo);
 }
 
 /* --- Base Styles --- */
@@ -194,12 +230,11 @@ html, body {
     flex-direction: column;
     justify-content: space-between;
     overflow: hidden;
-    line-height: 1.6;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     font-family: var(--mvnpm-font-sans);
-    font-size: var(--lumo-font-size-m);
-    line-height: var(--lumo-line-height-m);
+    font-size: var(--mvnpm-font-size-m);
+    line-height: var(--mvnpm-line-height-m);
     color: var(--mvnpm-text-primary);
     background-color: var(--mvnpm-bg-primary);
     transition: background-color 0.2s ease, color 0.2s ease;

--- a/src/test/java/io/mvnpm/UITest.java
+++ b/src/test/java/io/mvnpm/UITest.java
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.microsoft.playwright.BrowserContext;
-import com.microsoft.playwright.ElementHandle;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Response;
+import com.microsoft.playwright.options.WaitForSelectorState;
 
 import io.quarkiverse.playwright.InjectPlaywright;
 import io.quarkiverse.playwright.WithPlaywright;
@@ -55,13 +55,9 @@ public class UITest {
                 "mvnpm - Use NPM packages as Maven/Gradle dependencies",
                 title);
 
-        final ElementHandle coordinatesInputEl = page.waitForSelector("#coordinates-field input");
-        coordinatesInputEl.click();
-        coordinatesInputEl.fill("lit");
-        coordinatesInputEl.press("Enter");
-        final ElementHandle depEl = page.waitForSelector("#pom-dependency-code");
-        Assertions.assertTrue(depEl.getAttribute("content").contains("<artifactId>lit</artifactId>"),
-                "contains <artifactId>lit</artifactId>");
+        // Check that the SPA component is present in the DOM
+        page.waitForSelector("mvnpm-home",
+                new Page.WaitForSelectorOptions().setState(WaitForSelectorState.ATTACHED));
 
     }
 
@@ -113,7 +109,8 @@ public class UITest {
         Assertions.assertTrue(title.contains("Releases"),
                 "Releases page title should contain 'Releases'");
         // Check that the SPA component rendered
-        page.waitForSelector("mvnpm-releases");
+        page.waitForSelector("mvnpm-releases",
+                new Page.WaitForSelectorOptions().setState(WaitForSelectorState.ATTACHED));
     }
 
     @Test
@@ -127,7 +124,8 @@ public class UITest {
         String title = page.title();
         Assertions.assertTrue(title.contains("Live"),
                 "Live page title should contain 'Live'");
-        page.waitForSelector("mvnpm-live");
+        page.waitForSelector("mvnpm-live",
+                new Page.WaitForSelectorOptions().setState(WaitForSelectorState.ATTACHED));
     }
 
     @Test
@@ -141,7 +139,8 @@ public class UITest {
         String title = page.title();
         Assertions.assertTrue(title.contains("Composites"),
                 "Composites page title should contain 'Composites'");
-        page.waitForSelector("mvnpm-composites");
+        page.waitForSelector("mvnpm-composites",
+                new Page.WaitForSelectorOptions().setState(WaitForSelectorState.ATTACHED));
     }
 
     @Test


### PR DESCRIPTION
## Summary

2 more hours of working on this unplanned 😭

- **Quarkus upgrade**: 3.27.1 → 3.32.4 (brings Vaadin 24.8.3 → 25.0.4)
- **Vaadin 25 CSS migration**: Replace `--lumo-*` with `--vaadin-*` CSS custom properties for component theming. Keep `--lumo-*` overrides for `qui-card`/`qui-badge` which still use Lumo.
- **Search click bug fix**: Remove `@focusout` handler that raced with click events — clicking a search result no longer requires two clicks
- **Browser history**: Add `popstate` handler so back/forward buttons work between search results and package views
- **Layout fixes**: Desktop search scrollbar at screen edge, mobile search padding, progress bar sizing, selected tab color in shadow DOM

