### PR TITLE
Fix Vaadin 25 theming and restore missing dep versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ nbactions.xml
 # Claude Code
 .claude/
 .playwright-mcp/
+screenshot*.png
+*-screenshot*.png

--- a/.locker/pom.xml
+++ b/.locker/pom.xml
@@ -9,12 +9,14 @@
   <artifactId>mvnpm-locker</artifactId>
   <packaging>pom</packaging>
 
+  <!-- Locked dependencies (Update with 'mvn io.mvnpm:locker-maven-plugin:LATEST:lock -Dunlocked') -->
+
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>org.mvnpm.at.codemirror</groupId>
         <artifactId>autocomplete</artifactId>
-        <version>6.18.6</version>
+        <version>6.18.7</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -44,7 +46,7 @@
       <dependency>
         <groupId>org.mvnpm.at.codemirror</groupId>
         <artifactId>lang-html</artifactId>
-        <version>6.4.9</version>
+        <version>6.4.11</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -56,7 +58,7 @@
       <dependency>
         <groupId>org.mvnpm.at.codemirror</groupId>
         <artifactId>lang-javascript</artifactId>
-        <version>6.2.4</version>
+        <version>6.2.5</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -74,7 +76,7 @@
       <dependency>
         <groupId>org.mvnpm.at.codemirror</groupId>
         <artifactId>lang-markdown</artifactId>
-        <version>6.3.3</version>
+        <version>6.3.4</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -116,25 +118,25 @@
       <dependency>
         <groupId>org.mvnpm.at.codemirror</groupId>
         <artifactId>lang-yaml</artifactId>
-        <version>6.1.2</version>
+        <version>6.1.3</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.codemirror</groupId>
         <artifactId>language</artifactId>
-        <version>6.11.2</version>
+        <version>6.11.3</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.codemirror</groupId>
         <artifactId>lint</artifactId>
-        <version>6.8.5</version>
+        <version>6.9.5</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.codemirror</groupId>
         <artifactId>state</artifactId>
-        <version>6.5.2</version>
+        <version>6.5.4</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -142,6 +144,18 @@
         <artifactId>view</artifactId>
         <version>6.36.8</version>
         <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mvnpm.at.deno</groupId>
+        <artifactId>darwin-arm64</artifactId>
+        <version>2.5.4</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mvnpm.at.esbuild</groupId>
+        <artifactId>darwin-arm64</artifactId>
+        <version>0.25.10</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.fortawesome</groupId>
@@ -176,19 +190,19 @@
       <dependency>
         <groupId>org.mvnpm.at.lezer</groupId>
         <artifactId>common</artifactId>
-        <version>1.2.3</version>
+        <version>1.5.1</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.lezer</groupId>
         <artifactId>cpp</artifactId>
-        <version>1.1.3</version>
+        <version>1.1.5</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.lezer</groupId>
         <artifactId>css</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.3</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -200,13 +214,13 @@
       <dependency>
         <groupId>org.mvnpm.at.lezer</groupId>
         <artifactId>highlight</artifactId>
-        <version>1.2.1</version>
+        <version>1.2.3</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.lezer</groupId>
         <artifactId>html</artifactId>
-        <version>1.3.10</version>
+        <version>1.3.13</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -218,7 +232,7 @@
       <dependency>
         <groupId>org.mvnpm.at.lezer</groupId>
         <artifactId>javascript</artifactId>
-        <version>1.5.1</version>
+        <version>1.5.4</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -230,19 +244,19 @@
       <dependency>
         <groupId>org.mvnpm.at.lezer</groupId>
         <artifactId>lr</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.8</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.lezer</groupId>
         <artifactId>markdown</artifactId>
-        <version>1.4.3</version>
+        <version>1.6.3</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.lezer</groupId>
         <artifactId>php</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.5</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -272,19 +286,19 @@
       <dependency>
         <groupId>org.mvnpm.at.lezer</groupId>
         <artifactId>yaml</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.lit-labs</groupId>
         <artifactId>ssr-dom-shim</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.1</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.lit</groupId>
         <artifactId>reactive-element</artifactId>
-        <version>2.1.1</version>
+        <version>2.1.2</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -296,19 +310,13 @@
       <dependency>
         <groupId>org.mvnpm.at.mvnpm</groupId>
         <artifactId>vaadin-webcomponents</artifactId>
-        <version>24.8.3</version>
+        <version>25.0.4</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.open-wc</groupId>
         <artifactId>dedupe-mixin</artifactId>
         <version>1.4.0</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.mvnpm.at.polymer</groupId>
-        <artifactId>polymer</artifactId>
-        <version>3.5.2</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -344,7 +352,7 @@
       <dependency>
         <groupId>org.mvnpm.at.vaadin</groupId>
         <artifactId>router</artifactId>
-        <version>1.7.5</version>
+        <version>2.0.1</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -357,12 +365,6 @@
         <groupId>org.mvnpm.at.vaadin</groupId>
         <artifactId>vaadin-usage-statistics</artifactId>
         <version>2.1.3</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.mvnpm.at.webcomponents</groupId>
-        <artifactId>shadycss</artifactId>
-        <version>1.11.2</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -386,8 +388,20 @@
       <dependency>
         <groupId>org.mvnpm</groupId>
         <artifactId>dompurify</artifactId>
-        <version>3.2.6</version>
+        <version>3.2.7</version>
         <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mvnpm</groupId>
+        <artifactId>esbuild</artifactId>
+        <version>0.25.10</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mvnpm</groupId>
+        <artifactId>highlight.js</artifactId>
+        <version>11.11.1</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm</groupId>
@@ -398,43 +412,49 @@
       <dependency>
         <groupId>org.mvnpm</groupId>
         <artifactId>lit-element</artifactId>
-        <version>4.2.1</version>
+        <version>4.2.2</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm</groupId>
         <artifactId>lit-html</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm</groupId>
         <artifactId>lit</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm</groupId>
         <artifactId>marked</artifactId>
-        <version>16.0.0</version>
+        <version>17.0.1</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm</groupId>
         <artifactId>path-to-regexp</artifactId>
-        <version>2.4.0</version>
+        <version>6.3.0</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm</groupId>
         <artifactId>style-mod</artifactId>
-        <version>4.1.2</version>
+        <version>4.1.3</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.mvnpm</groupId>
-        <artifactId>style-observer</artifactId>
-        <version>0.0.8</version>
+        <artifactId>tagged-tag</artifactId>
+        <version>1.0.0</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mvnpm</groupId>
+        <artifactId>type-fest</artifactId>
+        <version>5.4.3</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,7 @@
     <dependency>
 	<groupId>org.mvnpm.at.qomponent</groupId>
 	<artifactId>qui-code-block</artifactId>
+	<version>1.1.1</version>
 	<scope>provided</scope>
     </dependency>
     <!-- Syntax highlighting for doc pages -->
@@ -247,6 +248,7 @@
     <dependency>
       <groupId>org.mvnpm</groupId>
       <artifactId>compare-versions</artifactId>
+      <version>6.1.1</version>
       <scope>provided</scope>
     </dependency>
     <!-- To render Markdown -->
@@ -259,12 +261,14 @@
     <dependency>
 	<groupId>org.mvnpm.at.qomponent</groupId>
 	<artifactId>qui-card</artifactId>
+	<version>1.0.2</version>
 	<scope>provided</scope>
     </dependency>
     <!-- Badges for display -->
     <dependency>
 	<groupId>org.mvnpm.at.qomponent</groupId>
 	<artifactId>qui-badge</artifactId>
+	<version>1.0.4</version>
 	<scope>provided</scope>
     </dependency>
     <!-- Testing -->

--- a/src/main/resources/web/app/mvnpm-composites.ts
+++ b/src/main/resources/web/app/mvnpm-composites.ts
@@ -30,10 +30,6 @@ export class MvnpmComposites extends ThemeMixin(LitElement) {
         box-sizing: border-box;
     }
 
-    vaadin-tab[selected] {
-        --vaadin-tab-text-color: var(--vaadin-selection-color, var(--lumo-primary-color));
-    }
-
     @media (min-width: 769px) {
         :host {
             overflow: hidden;

--- a/src/main/resources/web/app/mvnpm-composites.ts
+++ b/src/main/resources/web/app/mvnpm-composites.ts
@@ -31,7 +31,7 @@ export class MvnpmComposites extends ThemeMixin(LitElement) {
     }
 
     vaadin-tab[selected] {
-        --vaadin-tab-text-color: var(--lumo-primary-color);
+        --vaadin-tab-text-color: var(--vaadin-selection-color, var(--lumo-primary-color));
     }
 
     @media (min-width: 769px) {

--- a/src/main/resources/web/app/mvnpm-home.ts
+++ b/src/main/resources/web/app/mvnpm-home.ts
@@ -63,14 +63,6 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
           height: 4px;
       }
 
-      vaadin-tab[selected] {
-          --vaadin-tab-text-color: var(--vaadin-selection-color, var(--lumo-primary-color));
-      }
-
-      vaadin-radio-button[checked] {
-          --vaadin-radio-button-background: var(--vaadin-selection-color, var(--lumo-primary-color));
-      }
-
       .coordinates-name {
           width: 500px;
       }
@@ -808,6 +800,7 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
     return html`
       <div class="coordinates">
         <vaadin-text-field id="coordinates-field" label="Name (Package or Coordinates)" class="coordinates-name"
+                           autocomplete="off"
                            @keypress="${this._findVersionsAndShowLatest}"
                            @input="${this._coordinatesNameChanged}"
                            value="${this._coordinates.name}" clear-button-visible></vaadin-text-field>
@@ -1075,7 +1068,7 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
               <div slot="content">
                 <qui-code-block id="pom-dependency-code" mode="xml" theme="${this._theme}" content="${this._usePom}"></qui-code-block>
               </div>
-              <div slot="footer" style="display:flex; justify-content:center; padding:4px 8px;">
+              <div slot="footer">
                 <vaadin-radio-group theme="horizontal" @change="${this._scopeChanged}">
                   <vaadin-radio-button value="runtime" label="runtime"></vaadin-radio-button>
                   <vaadin-radio-button value="provided" label="provided" checked></vaadin-radio-button>

--- a/src/main/resources/web/app/mvnpm-home.ts
+++ b/src/main/resources/web/app/mvnpm-home.ts
@@ -64,7 +64,11 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
       }
 
       vaadin-tab[selected] {
-          --vaadin-tab-text-color: var(--lumo-primary-color);
+          --vaadin-tab-text-color: var(--vaadin-selection-color, var(--lumo-primary-color));
+      }
+
+      vaadin-radio-button[checked] {
+          --vaadin-radio-button-background: var(--vaadin-selection-color, var(--lumo-primary-color));
       }
 
       .coordinates-name {
@@ -1071,8 +1075,8 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
               <div slot="content">
                 <qui-code-block id="pom-dependency-code" mode="xml" theme="${this._theme}" content="${this._usePom}"></qui-code-block>
               </div>
-              <div slot="footer">
-                <vaadin-radio-group @change="${this._scopeChanged}">
+              <div slot="footer" style="display:flex; justify-content:center; padding:4px 8px;">
+                <vaadin-radio-group theme="horizontal" @change="${this._scopeChanged}">
                   <vaadin-radio-button value="runtime" label="runtime"></vaadin-radio-button>
                   <vaadin-radio-button value="provided" label="provided" checked></vaadin-radio-button>
                 </vaadin-radio-group>
@@ -1103,6 +1107,11 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
 
   _pomToClipboard() {
     navigator.clipboard.writeText(this._usePom);
+    Notification.show('Copied to clipboard!', {
+      position: 'top-center',
+      duration: 2000,
+      theme: 'success',
+    });
   }
 
   _viewDependency(dependency) {

--- a/src/main/resources/web/app/mvnpm-live.ts
+++ b/src/main/resources/web/app/mvnpm-live.ts
@@ -32,9 +32,6 @@ export class MvnpmLive extends LitElement {
             padding: 8px;
         }
 
-        vaadin-checkbox[checked] {
-            --vaadin-checkbox-background: var(--vaadin-selection-color, var(--lumo-primary-color));
-        }
     `;
 
     @state({type: Boolean})

--- a/src/main/resources/web/app/mvnpm-live.ts
+++ b/src/main/resources/web/app/mvnpm-live.ts
@@ -31,6 +31,10 @@ export class MvnpmLive extends LitElement {
             justify-content: center;
             padding: 8px;
         }
+
+        vaadin-checkbox[checked] {
+            --vaadin-checkbox-background: var(--vaadin-selection-color, var(--lumo-primary-color));
+        }
     `;
 
     @state({type: Boolean})

--- a/src/main/resources/web/app/mvnpm-releases.ts
+++ b/src/main/resources/web/app/mvnpm-releases.ts
@@ -39,6 +39,10 @@ export class MvnpmReleases extends LitElement {
         border-radius: var(--mvnpm-radius-md, 10px);
     }
 
+    vaadin-radio-button[checked] {
+        --vaadin-radio-button-background: var(--vaadin-selection-color, var(--lumo-primary-color));
+    }
+
     vaadin-grid {
         border-radius: var(--mvnpm-radius-md, 10px);
         border: 1px solid var(--mvnpm-border, var(--lumo-contrast-10pct));

--- a/src/main/resources/web/app/mvnpm-releases.ts
+++ b/src/main/resources/web/app/mvnpm-releases.ts
@@ -39,10 +39,6 @@ export class MvnpmReleases extends LitElement {
         border-radius: var(--mvnpm-radius-md, 10px);
     }
 
-    vaadin-radio-button[checked] {
-        --vaadin-radio-button-background: var(--vaadin-selection-color, var(--lumo-primary-color));
-    }
-
     vaadin-grid {
         border-radius: var(--mvnpm-radius-md, 10px);
         border: 1px solid var(--mvnpm-border, var(--lumo-contrast-10pct));

--- a/src/main/resources/web/app/mvnpm.css
+++ b/src/main/resources/web/app/mvnpm.css
@@ -111,6 +111,12 @@ html[data-theme="dark"], html:not([data-theme]) {
     --vaadin-border-color-secondary: var(--mvnpm-border-subtle);
     --vaadin-focus-ring-color: var(--mvnpm-indigo-light);
     --vaadin-radius-m: var(--mvnpm-radius-sm);
+    --vaadin-selection-color: var(--mvnpm-indigo-light);
+    --vaadin-selection-color-text: #ffffff;
+    /* Radio & checkbox sizing (1lh is too large with our line-height) */
+    --vaadin-radio-button-size: 1em;
+    --vaadin-checkbox-size: 1em;
+    /* Input fields */
     --vaadin-input-field-background: var(--mvnpm-bg-surface);
     --vaadin-input-field-border-color: var(--mvnpm-border);
     --vaadin-input-field-value-color: var(--mvnpm-text-primary);
@@ -121,10 +127,24 @@ html[data-theme="dark"], html:not([data-theme]) {
     --vaadin-input-field-button-text-color: var(--mvnpm-text-secondary);
     --vaadin-input-field-required-indicator: none;
     --vaadin-input-field-required-indicator-color: var(--mvnpm-text-tertiary);
+    /* Buttons */
     --vaadin-button-text-color: var(--mvnpm-text-secondary);
     --vaadin-button-border-color: var(--mvnpm-border);
+    --vaadin-button-primary-background: var(--mvnpm-indigo-light);
+    --vaadin-button-primary-text-color: #ffffff;
+    /* Progress bar */
     --vaadin-progress-bar-background: var(--mvnpm-bg-surface);
     --vaadin-progress-bar-value-background: var(--mvnpm-indigo-light);
+    /* Tabs */
+    /* Tabs: no global selected-text-color; override via vaadin-tab[selected] in components */
+    /* Grid */
+    --vaadin-grid-header-background: var(--mvnpm-bg-surface);
+    --vaadin-grid-row-stripe-background: var(--mvnpm-bg-surface);
+    --vaadin-grid-border-color: var(--mvnpm-border);
+    /* Overlay (combo-box dropdowns, etc.) */
+    --vaadin-overlay-background: var(--mvnpm-bg-elevated);
+    --vaadin-overlay-border-color: var(--mvnpm-border);
+    --vaadin-item-checkmark-color: var(--mvnpm-indigo-light);
 }
 
 /* --- Light Theme --- */
@@ -205,6 +225,12 @@ html[data-theme="light"] {
     --vaadin-border-color-secondary: var(--mvnpm-border-subtle);
     --vaadin-focus-ring-color: var(--mvnpm-indigo);
     --vaadin-radius-m: var(--mvnpm-radius-sm);
+    --vaadin-selection-color: var(--mvnpm-indigo);
+    --vaadin-selection-color-text: #ffffff;
+    /* Radio & checkbox sizing (1lh is too large with our line-height) */
+    --vaadin-radio-button-size: 1em;
+    --vaadin-checkbox-size: 1em;
+    /* Input fields */
     --vaadin-input-field-background: var(--mvnpm-bg-surface);
     --vaadin-input-field-border-color: var(--mvnpm-border);
     --vaadin-input-field-value-color: var(--mvnpm-text-primary);
@@ -215,10 +241,24 @@ html[data-theme="light"] {
     --vaadin-input-field-button-text-color: var(--mvnpm-text-secondary);
     --vaadin-input-field-required-indicator: none;
     --vaadin-input-field-required-indicator-color: var(--mvnpm-text-tertiary);
+    /* Buttons */
     --vaadin-button-text-color: var(--mvnpm-text-secondary);
     --vaadin-button-border-color: var(--mvnpm-border);
+    --vaadin-button-primary-background: var(--mvnpm-indigo);
+    --vaadin-button-primary-text-color: #ffffff;
+    /* Progress bar */
     --vaadin-progress-bar-background: var(--mvnpm-bg-surface);
     --vaadin-progress-bar-value-background: var(--mvnpm-indigo);
+    /* Tabs */
+    /* Tabs: no global selected-text-color; override via vaadin-tab[selected] in components */
+    /* Grid */
+    --vaadin-grid-header-background: var(--mvnpm-bg-surface);
+    --vaadin-grid-row-stripe-background: var(--mvnpm-bg-surface);
+    --vaadin-grid-border-color: var(--mvnpm-border);
+    /* Overlay (combo-box dropdowns, etc.) */
+    --vaadin-overlay-background: var(--mvnpm-bg-elevated);
+    --vaadin-overlay-border-color: var(--mvnpm-border);
+    --vaadin-item-checkmark-color: var(--mvnpm-indigo);
 }
 
 /* --- Base Styles --- */

--- a/src/main/resources/web/app/mvnpm.css
+++ b/src/main/resources/web/app/mvnpm.css
@@ -1,5 +1,8 @@
 /* ===== MVNPM Design System ===== */
 
+/* --- Vaadin Lumo Theme (auto-injected into component shadow DOMs) --- */
+@import '@vaadin/vaadin-lumo-styles/lumo.css';
+
 /* --- Theme Variables --- */
 :root {
     /* Brand colors */
@@ -74,9 +77,19 @@ html[data-theme="dark"], html:not([data-theme]) {
     --lumo-contrast: var(--mvnpm-text-primary);
     --lumo-contrast-90pct: rgba(240, 240, 244, 0.9);
     --lumo-contrast-80pct: rgba(240, 240, 244, 0.8);
+    --lumo-contrast-70pct: rgba(240, 240, 244, 0.7);
+    --lumo-contrast-60pct: rgba(240, 240, 244, 0.6);
     --lumo-contrast-50pct: rgba(240, 240, 244, 0.5);
+    --lumo-contrast-40pct: rgba(240, 240, 244, 0.4);
+    --lumo-contrast-30pct: rgba(240, 240, 244, 0.3);
+    --lumo-contrast-20pct: rgba(240, 240, 244, 0.2);
     --lumo-contrast-10pct: rgba(240, 240, 244, 0.1);
     --lumo-contrast-5pct: rgba(240, 240, 244, 0.05);
+    --lumo-header-text-color: var(--mvnpm-text-primary);
+    --lumo-body-text-color: var(--mvnpm-text-primary);
+    --lumo-secondary-text-color: var(--mvnpm-text-secondary);
+    --lumo-tertiary-text-color: var(--mvnpm-text-tertiary);
+    --lumo-disabled-text-color: var(--mvnpm-text-tertiary);
     --lumo-primary-color: var(--mvnpm-indigo-light);
     --lumo-primary-text-color: var(--mvnpm-indigo-light);
     --lumo-primary-color-10pct: rgba(99, 102, 241, 0.1);
@@ -100,6 +113,7 @@ html[data-theme="dark"], html:not([data-theme]) {
     --lumo-border-radius-s: var(--mvnpm-radius-sm);
 
     /* Vaadin component overrides */
+    --lumo-clickable-cursor: pointer;
     --vaadin-clickable-cursor: pointer;
     --vaadin-text-color: var(--mvnpm-text-primary);
     --vaadin-text-color-secondary: var(--mvnpm-text-secondary);
@@ -112,10 +126,6 @@ html[data-theme="dark"], html:not([data-theme]) {
     --vaadin-focus-ring-color: var(--mvnpm-indigo-light);
     --vaadin-radius-m: var(--mvnpm-radius-sm);
     --vaadin-selection-color: var(--mvnpm-indigo-light);
-    --vaadin-selection-color-text: #ffffff;
-    /* Radio & checkbox sizing (1lh is too large with our line-height) */
-    --vaadin-radio-button-size: 1em;
-    --vaadin-checkbox-size: 1em;
     /* Input fields */
     --vaadin-input-field-background: var(--mvnpm-bg-surface);
     --vaadin-input-field-border-color: var(--mvnpm-border);
@@ -135,8 +145,6 @@ html[data-theme="dark"], html:not([data-theme]) {
     /* Progress bar */
     --vaadin-progress-bar-background: var(--mvnpm-bg-surface);
     --vaadin-progress-bar-value-background: var(--mvnpm-indigo-light);
-    /* Tabs */
-    /* Tabs: no global selected-text-color; override via vaadin-tab[selected] in components */
     /* Grid */
     --vaadin-grid-header-background: var(--mvnpm-bg-surface);
     --vaadin-grid-row-stripe-background: var(--mvnpm-bg-surface);
@@ -188,9 +196,19 @@ html[data-theme="light"] {
     --lumo-contrast: var(--mvnpm-text-primary);
     --lumo-contrast-90pct: rgba(24, 24, 27, 0.9);
     --lumo-contrast-80pct: rgba(24, 24, 27, 0.8);
+    --lumo-contrast-70pct: rgba(24, 24, 27, 0.7);
+    --lumo-contrast-60pct: rgba(24, 24, 27, 0.6);
     --lumo-contrast-50pct: rgba(24, 24, 27, 0.5);
+    --lumo-contrast-40pct: rgba(24, 24, 27, 0.4);
+    --lumo-contrast-30pct: rgba(24, 24, 27, 0.3);
+    --lumo-contrast-20pct: rgba(24, 24, 27, 0.2);
     --lumo-contrast-10pct: rgba(24, 24, 27, 0.1);
     --lumo-contrast-5pct: rgba(24, 24, 27, 0.05);
+    --lumo-header-text-color: var(--mvnpm-text-primary);
+    --lumo-body-text-color: var(--mvnpm-text-primary);
+    --lumo-secondary-text-color: var(--mvnpm-text-secondary);
+    --lumo-tertiary-text-color: var(--mvnpm-text-tertiary);
+    --lumo-disabled-text-color: var(--mvnpm-text-tertiary);
     --lumo-primary-color: var(--mvnpm-indigo);
     --lumo-primary-text-color: var(--mvnpm-indigo);
     --lumo-primary-color-10pct: rgba(99, 102, 241, 0.1);
@@ -214,6 +232,7 @@ html[data-theme="light"] {
     --lumo-border-radius-s: var(--mvnpm-radius-sm);
 
     /* Vaadin component overrides */
+    --lumo-clickable-cursor: pointer;
     --vaadin-clickable-cursor: pointer;
     --vaadin-text-color: var(--mvnpm-text-primary);
     --vaadin-text-color-secondary: var(--mvnpm-text-secondary);
@@ -226,10 +245,6 @@ html[data-theme="light"] {
     --vaadin-focus-ring-color: var(--mvnpm-indigo);
     --vaadin-radius-m: var(--mvnpm-radius-sm);
     --vaadin-selection-color: var(--mvnpm-indigo);
-    --vaadin-selection-color-text: #ffffff;
-    /* Radio & checkbox sizing (1lh is too large with our line-height) */
-    --vaadin-radio-button-size: 1em;
-    --vaadin-checkbox-size: 1em;
     /* Input fields */
     --vaadin-input-field-background: var(--mvnpm-bg-surface);
     --vaadin-input-field-border-color: var(--mvnpm-border);
@@ -249,8 +264,6 @@ html[data-theme="light"] {
     /* Progress bar */
     --vaadin-progress-bar-background: var(--mvnpm-bg-surface);
     --vaadin-progress-bar-value-background: var(--mvnpm-indigo);
-    /* Tabs */
-    /* Tabs: no global selected-text-color; override via vaadin-tab[selected] in components */
     /* Grid */
     --vaadin-grid-header-background: var(--mvnpm-bg-surface);
     --vaadin-grid-row-stripe-background: var(--mvnpm-bg-surface);


### PR DESCRIPTION
## Summary

- Import `@vaadin/vaadin-lumo-styles/lumo.css` so the Lumo theme auto-injects into Vaadin component shadow DOMs (root cause of all Vaadin 25 styling issues)
- Add complete `--lumo-contrast-*` scale (5–90pct) and `--lumo-*-text-color` overrides so Lumo internals resolve to our design system colors
- Add `--lumo-clickable-cursor: pointer` for proper cursor on radio buttons, checkboxes, tabs, and buttons
- Remove `--vaadin-selection-color-text: #ffffff` which made selected tab text invisible on light backgrounds
- Remove per-component workarounds (`vaadin-radio-button[checked]`, `vaadin-checkbox[checked]`, `vaadin-tab[selected]`) — Lumo handles these now
- Remove manual radio/checkbox sizing — Lumo sets proper sizes
- Add `autocomplete="off"` to search field to prevent ugly browser autocomplete

## Test plan

- [x] All 8 UI tests pass (`./mvnw test -Dtest=UITest`)
- [x] Dark mode: package view, releases, live pages verified
- [x] Light mode: package view, tab text visible, radio buttons correct
- [x] Radio buttons use Lumo default sizing and pointer cursor
- [x] Selected tabs show indigo text (not white) in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)