### PR TITLE
Fix mobile padding and frontmatter-driven nav visibility

### DIFF
--- a/src/main/resources/content/about.md
+++ b/src/main/resources/content/about.md
@@ -1,8 +1,9 @@
 ---
 layout: doc
 nav:
-  order: 6
+  order: 7
   title: About
+  mobile: true
 title: "About mvnpm"
 description: "The story behind mvnpm, why it exists, and the ecosystem of tools that make frontend development in Java seamless."
 image: og-image.png

--- a/src/main/resources/content/ai-agent.md
+++ b/src/main/resources/content/ai-agent.md
@@ -1,8 +1,9 @@
 ---
 layout: doc
 nav:
-  order: 7
+  order: 3
   title: MCP
+  mobile: false
 title: "AI Agent Integration"
 description: "Connect your AI coding assistant to mvnpm via MCP (Model Context Protocol). Setup guides for Claude Code, Cursor, VS Code, Windsurf, and more."
 image: og-image.png

--- a/src/main/resources/content/composites.html
+++ b/src/main/resources/content/composites.html
@@ -1,8 +1,9 @@
 ---
 layout: app
 nav:
-  order: 5
+  order: 6
   title: Composites
+  mobile: false
 title: "Composites - mvnpm"
 description: "Browse and manage composite packages that aggregate multiple NPM packages into a single Maven artifact."
 image: og-image.png

--- a/src/main/resources/content/doc.md
+++ b/src/main/resources/content/doc.md
@@ -3,6 +3,7 @@ layout: doc
 nav:
   order: 2
   title: Getting Started
+  mobile: true
 title: "Getting Started with mvnpm"
 description: "Use NPM packages as standard Maven or Gradle dependencies. Learn how to add NPM dependencies, configure the fallback repository, and lock versions."
 image: og-image.png

--- a/src/main/resources/content/index.html
+++ b/src/main/resources/content/index.html
@@ -3,6 +3,7 @@ layout: app
 nav:
   order: 1
   title: Browse
+  mobile: true
 title: "mvnpm - Use NPM packages as Maven/Gradle dependencies"
 description: "Seamlessly integrate NPM packages into Java through Maven and Gradle dependencies. The bridge between NPM and Maven Central."
 image: og-image.png

--- a/src/main/resources/content/live.html
+++ b/src/main/resources/content/live.html
@@ -1,8 +1,9 @@
 ---
 layout: app
 nav:
-  order: 4
+  order: 5
   title: Live
+  mobile: false
 title: "Live - mvnpm"
 description: "Watch live synchronization progress of NPM packages being converted to Maven artifacts."
 image: og-image.png

--- a/src/main/resources/content/releases.html
+++ b/src/main/resources/content/releases.html
@@ -1,8 +1,9 @@
 ---
 layout: app
 nav:
-  order: 3
+  order: 4
   title: Releases
+  mobile: false
 title: "Releases - mvnpm"
 description: "Track Maven Central sync status for NPM packages. Monitor packaging, uploading, and release stages."
 image: og-image.png

--- a/src/main/resources/templates/layouts/main.html
+++ b/src/main/resources/templates/layouts/main.html
@@ -100,7 +100,7 @@
         <div class="header-right">
             <nav>
                 {#for p in site.pages.sortedByNav}
-                <a href="{p.url}" {#if p.id == page.id}data-selected{/if}>{p.data.nav.title}</a>
+                <a href="{p.url}" {#if p.id == page.id}data-selected{/if} {#if !p.data.nav.mobile??}class="nav-desktop-only"{/if}>{p.data.nav.title}</a>
                 {/for}
                 <a href="https://github.com/mvnpm/mvnpm" target="_blank" title="Source on GitHub">
                     <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">

--- a/src/main/resources/web/app/mvnpm-home.ts
+++ b/src/main/resources/web/app/mvnpm-home.ts
@@ -670,6 +670,11 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
           }
           .recent-section {
               padding: 12px 16px 24px;
+              box-sizing: border-box;
+          }
+          .mcp-card {
+              margin: 16px 16px 0;
+              width: auto;
           }
           .recent-grid {
               grid-template-columns: 1fr 1fr;

--- a/src/main/resources/web/app/mvnpm.css
+++ b/src/main/resources/web/app/mvnpm.css
@@ -634,7 +634,7 @@ footer .copyright {
         font-size: 0.85rem;
     }
 
-    nav a[href*="/live"], nav a[href*="/composites"], nav a[href*="/releases"] {
+    nav a.nav-desktop-only {
         display: none;
     }
 


### PR DESCRIPTION
## Summary
- Fix MCP card touching screen edges on mobile by adding proper margins
- Move MCP nav link to 3rd position in navigation order
- Replace hardcoded CSS selectors for hiding nav items on mobile with a frontmatter `mobile: true/false` flag and `nav-desktop-only` CSS class
- Hide MCP, Releases, Live, and Composites from mobile nav

## Test plan
- [x] Verify MCP card has proper padding on mobile (375px viewport)
- [x] Verify desktop nav shows: Browse, Getting Started, MCP, Releases, Live, Composites, About
- [x] Verify mobile nav shows only: Browse, Getting Started, About
- [x] Verify adding `mobile: true/false` to a page's frontmatter controls its mobile nav visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)