### PR TITLE
Add cache-busting UUID to static assets

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 copyright.year=2025
+build.id=${quarkus.uuid}
 quarkus.banner.path=asciiart.txt
 quarkus.test.integration-test-profile=test
 

--- a/src/main/resources/templates/layouts/main.html
+++ b/src/main/resources/templates/layouts/main.html
@@ -5,8 +5,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="{site.file('static/favicon.svg')}">
-    <link rel="icon" type="image/x-icon" sizes="64x64 32x32 16x16" href="{site.file('static/favicon.ico')}">
+    <link rel="icon" type="image/svg+xml" href="{site.file('static/favicon.svg')}?v={config:['build.id']}">
+    <link rel="icon" type="image/x-icon" sizes="64x64 32x32 16x16" href="{site.file('static/favicon.ico')}?v={config:['build.id']}">
     {#bundle /}
 
     <!-- Roq handles: title, description, og:title, og:description, og:image, og:url, twitter:title, twitter:description, twitter:image -->
@@ -94,8 +94,8 @@
 <body>
     <header>
         <div class="banner" onclick="location.href='/';">
-            <img class="logo-dark" src="{site.file('static/logo.svg')}" alt="mvnpm"/>
-            <img class="logo-light" src="{site.file('static/logo-reversed.svg')}" alt="mvnpm"/>
+            <img class="logo-dark" src="{site.file('static/logo.svg')}?v={config:['build.id']}" alt="mvnpm"/>
+            <img class="logo-light" src="{site.file('static/logo-reversed.svg')}?v={config:['build.id']}" alt="mvnpm"/>
         </div>
         <div class="header-right">
             <nav>


### PR DESCRIPTION
## Summary
- Add `build.id=${quarkus.uuid}` property that generates a unique ID per startup
- Append `?v={build.id}` to favicon and logo asset URLs in the layout template
- Ensures browsers fetch fresh static assets after each deployment

## Test plan
- [x] Verify rendered HTML contains `?v=<uuid>` on favicon and logo URLs
- [x] Verify UUID changes on app restart
- [x] Verify bundled assets (handled by web-bundler) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)