### PR TITLE
Fix NPM registry connection pool exhaustion

### DIFF
--- a/src/main/java/io/mvnpm/mavencentral/sync/ContinuousSyncService.java
+++ b/src/main/java/io/mvnpm/mavencentral/sync/ContinuousSyncService.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 import jakarta.ws.rs.WebApplicationException;
 
 import org.apache.commons.io.FileUtils;

--- a/src/main/java/io/mvnpm/mavencentral/sync/ContinuousSyncService.java
+++ b/src/main/java/io/mvnpm/mavencentral/sync/ContinuousSyncService.java
@@ -148,7 +148,6 @@ public class ContinuousSyncService {
      */
     @Scheduled(every = "${mvnpm.check-packaging.every:60s}", concurrentExecution = SKIP)
     @Blocking
-    @Transactional
     void checkPackaging() {
         List<CentralSyncItem> initQueue = CentralSyncItem.findByStage(Stage.PACKAGING, 1);
         if (!initQueue.isEmpty()) {

--- a/src/main/java/io/mvnpm/npm/NpmRegistryFacade.java
+++ b/src/main/java/io/mvnpm/npm/NpmRegistryFacade.java
@@ -42,6 +42,8 @@ public class NpmRegistryFacade {
     }
 
     @CacheResult(cacheName = "npm-package-cache")
+    @Timeout(unit = ChronoUnit.MINUTES, value = 2)
+    @Retry(maxRetries = 2)
     @Blocking
     public io.mvnpm.npm.model.Package getPackage(String project, String version) {
         if (null == version || version.startsWith("git:/") || version.startsWith("git+http")) {
@@ -56,6 +58,7 @@ public class NpmRegistryFacade {
         }
     }
 
+    @Timeout(unit = ChronoUnit.MINUTES, value = 2)
     @Blocking
     public SearchResults search(String term, int page) {
         if (page < 0)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,8 @@ quarkus.test.integration-test-profile=test
 
 quarkus.rest-client.npm-registry.url=https://registry.npmjs.org
 quarkus.rest-client.npm-registry.verify-host=false
+quarkus.rest-client.npm-registry.connect-timeout=5000
+quarkus.rest-client.npm-registry.read-timeout=120000
 
 quarkus.rest-client.mavencentral.url=https://central.sonatype.com
 quarkus.rest-client.mavencentral.verify-host=false
@@ -49,6 +51,8 @@ mvnpm.checkall.cron.expr=0 0 0/4 * * ?
 mvnpm.checkerror.cron.expr=0 0 5 * * ?
 
 %dev.mvnpm.check-versions.every=30s
+
+%prod.mvnpm.check-packaging.every=10m
 
 quarkus.http.enable-compression=true
 


### PR DESCRIPTION
## Summary

- Add `@Timeout(2min)` on `NpmRegistryFacade.getPackage()` and `search()` — prevents indefinite thread/connection leaks when NPM registry is slow
- Remove `@Transactional` from `checkPackaging()` — called services already handle their own transactions; wrapping long REST calls in a TX triggers Transaction Reaper cascade
- Add `connect-timeout=5s` and `read-timeout=2min` for npm-registry REST client
- Increase `checkPackaging` interval to 10min in prod (was 60s)

## Root cause

When NPM registry becomes unresponsive, `getPackage()` blocks indefinitely in `CompletableFuture.get()` (no `@Timeout`). The `checkPackaging()` scheduler fires every 60s with `concurrentExecution = SKIP`, but the skip doesn't prevent connection leaks — old threads stay blocked after the scheduler considers them "done". Each cycle leaks one thread + one HTTP connection. After ~3 hours, the connection pool to `registry.npmjs.org:443` is exhausted and all user requests fail with `NoStackTraceTimeoutException`.

## Test plan

- [x] Verified all DB writes in `checkPackaging()` go through services with their own `@Transactional`
- [ ] Deploy and monitor thread count and connection pool usage
- [ ] Verify `getPackage()` and `search()` properly timeout after 2min

🤖 Generated with [Claude Code](https://claude.com/claude-code)