### PR TITLE
Fix event loop blocking and switch MCP to Streamable HTTP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
     <!-- MCP Server -->
     <dependency>
       <groupId>io.quarkiverse.mcp</groupId>
-      <artifactId>quarkus-mcp-server-sse</artifactId>
+      <artifactId>quarkus-mcp-server-http</artifactId>
       <version>1.10.3</version>
     </dependency>
     <!-- Web Bundler -->

--- a/src/main/java/io/mvnpm/maven/MavenRepositoryService.java
+++ b/src/main/java/io/mvnpm/maven/MavenRepositoryService.java
@@ -126,6 +126,7 @@ public class MavenRepositoryService {
                     return version != null ? new NameVersion(name, version.toString()) : null;
                 }).onItem().delayIt().by(Duration.ofSeconds(3)))
                 .filter(Objects::nonNull)
+                .emitOn(Infrastructure.getDefaultWorkerPool())
                 .invoke(n -> {
                     final String depGavString = n.name().toGavString(n.version());
                     Log.infof("Matching dependency version found for package %s -> %s", reqGavString, depGavString);

--- a/src/main/resources/content/ai-agent.md
+++ b/src/main/resources/content/ai-agent.md
@@ -13,14 +13,11 @@ image: og-image.png
 
 Connect your AI coding assistant to mvnpm using the **Model Context Protocol (MCP)**. Your agent can search NPM packages, get Maven coordinates, browse artifacts, and monitor sync status — all without leaving your editor.
 
-## Endpoints
+## Endpoint
 
-mvnpm exposes two MCP transport options:
-
-| Transport | URL | Notes |
-|-----------|-----|-------|
-| **SSE** (Server-Sent Events) | `https://mvnpm.org/mcp/sse` | Widest client support |
-| **Streamable HTTP** | `https://mvnpm.org/mcp` | Newer, simpler protocol |
+| Transport | URL |
+|-----------|-----|
+| **Streamable HTTP** | `https://mvnpm.org/mcp` |
 
 ## Available Tools
 
@@ -45,7 +42,7 @@ All tools accept both **NPM names** (`lit`, `@hotwired/stimulus`) and **Maven co
 ### Claude Code
 
 ```bash
-claude mcp add mvnpm --transport sse https://mvnpm.org/mcp/sse
+claude mcp add --transport http mvnpm https://mvnpm.org/mcp
 ```
 
 That's it. The mvnpm tools are now available in your Claude Code sessions.
@@ -58,7 +55,7 @@ Add to `.cursor/mcp.json` in your project root (or `~/.cursor/mcp.json` globally
 {
   "mcpServers": {
     "mvnpm": {
-      "url": "https://mvnpm.org/mcp/sse"
+      "url": "https://mvnpm.org/mcp"
     }
   }
 }
@@ -72,8 +69,8 @@ Add to `.vscode/mcp.json` in your project root:
 {
   "servers": {
     "mvnpm": {
-      "type": "sse",
-      "url": "https://mvnpm.org/mcp/sse"
+      "type": "http",
+      "url": "https://mvnpm.org/mcp"
     }
   }
 }
@@ -87,7 +84,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 {
   "mcpServers": {
     "mvnpm": {
-      "serverUrl": "https://mvnpm.org/mcp/sse"
+      "serverUrl": "https://mvnpm.org/mcp"
     }
   }
 }
@@ -95,10 +92,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 ### Generic / Other Clients
 
-Any MCP-compatible client can connect using:
-
-- **SSE**: `https://mvnpm.org/mcp/sse`
-- **Streamable HTTP**: `https://mvnpm.org/mcp`
+Any MCP-compatible client can connect to `https://mvnpm.org/mcp` using the [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http).
 
 Refer to your client's documentation for how to add a remote MCP server.
 


### PR DESCRIPTION
## Summary
- Adds `.emitOn(Infrastructure.getDefaultWorkerPool())` in `MavenRepositoryService` to move dependency resolution downstream processing (package creation) to the worker pool, fixing `The current thread cannot be blocked: vert.x-eventloop-thread-0` errors
- Switches MCP transport from SSE (`quarkus-mcp-server-sse`) to Streamable HTTP (`quarkus-mcp-server-http`) — SSE connections fail behind Cloudflare due to buffering/timeouts
- Updates MCP docs with new endpoint URL and setup instructions for all clients

## Test plan
- [ ] Verify dependency resolution completes without event loop blocking errors (e.g. `i18next` → `@babel/runtime`)
- [ ] Verify MCP endpoint works at `https://mvnpm.org/mcp` via `claude mcp add --transport http mvnpm https://mvnpm.org/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)