### PR TITLE
Add MCP server name and description

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,6 +16,10 @@ quarkus.rest-client.mavencentral.connect-timeout=30000
 quarkus.rest-client.github.url=https://api.github.com
 quarkus.rest-client.github.verify-host=false
 
+# MCP Server
+quarkus.mcp-server.server-info.name=mvnpm
+quarkus.mcp-server.server-info.description=Maven repository facade for NPM packages. Search, browse, and resolve NPM packages as Maven dependencies. Get Maven coordinates, POMs, import maps, and track Maven Central sync status for any NPM package.
+
 quarkus.websocket.dispatch-to-worker=true
 quarkus.scheduler.start-mode=forced
 


### PR DESCRIPTION
## Summary
- Adds `quarkus.mcp-server.server-info.name` and `quarkus.mcp-server.server-info.description` to `application.properties` so that MCP clients can identify the server and understand its capabilities.

## Test plan
- [x] Start in dev mode and verify the MCP server reports its name and description in the `initialize` response

🤖 Generated with [Claude Code](https://claude.com/claude-code)