### PR TITLE
Add index on SyncedPackage.nextCheck for batch claim queries

### DIFF
--- a/src/main/java/io/mvnpm/mavencentral/sync/SyncedPackage.java
+++ b/src/main/java/io/mvnpm/mavencentral/sync/SyncedPackage.java
@@ -6,11 +6,16 @@ import java.util.List;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 @Entity
 @IdClass(SyncedPackageId.class)
+@Table(indexes = {
+        @Index(columnList = "nextCheck")
+})
 public class SyncedPackage extends PanacheEntityBase {
     @Id
     public String groupId;


### PR DESCRIPTION
## Summary

- Adds a database index on `SyncedPackage.nextCheck` to optimize the `claimBatch()` query which runs every 5 minutes
- Without this index, `claimBatch()` does a full table scan on ~9000 rows filtering and sorting by `nextCheck`

## Test plan

- [x] `SyncedPackageClaimTest` (6 tests) — all pass
- [x] `ContinuousSyncServiceTest` (23 tests) — all pass
- Hibernate auto-creates the index via `quarkus.hibernate-orm.database.generation=update` in prod

🤖 Generated with [Claude Code](https://claude.ai/code)