### PR TITLE
Handle unpublished object in NPM time map deserialization

### DIFF
--- a/src/main/java/io/mvnpm/npm/model/Project.java
+++ b/src/main/java/io/mvnpm/npm/model/Project.java
@@ -13,5 +13,5 @@ public record Project(
         String homepage,
         @JsonDeserialize(using = LicenseDeserializer.class) License license,
         @JsonDeserialize(using = VersionDeserializer.class) Set<String> versions,
-        Map<String, String> time) {
+        @JsonDeserialize(using = TimeMapDeserializer.class) Map<String, String> time) {
 }

--- a/src/main/java/io/mvnpm/npm/model/TimeMapDeserializer.java
+++ b/src/main/java/io/mvnpm/npm/model/TimeMapDeserializer.java
@@ -1,0 +1,43 @@
+package io.mvnpm.npm.model;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+/**
+ * Deserializes the NPM "time" map, skipping entries whose values are not strings
+ * (e.g. the "unpublished" key which contains an object).
+ */
+public class TimeMapDeserializer extends StdDeserializer<Map<String, String>> {
+
+    public TimeMapDeserializer() {
+        this(null);
+    }
+
+    public TimeMapDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public Map<String, String> deserialize(JsonParser jp, DeserializationContext dc) throws IOException {
+        Map<String, String> result = new LinkedHashMap<>();
+        if (jp.currentToken() != JsonToken.START_OBJECT) {
+            return result;
+        }
+        while (jp.nextToken() != JsonToken.END_OBJECT) {
+            String key = jp.currentName();
+            jp.nextToken();
+            if (jp.currentToken() == JsonToken.VALUE_STRING) {
+                result.put(key, jp.getValueAsString());
+            } else {
+                jp.skipChildren();
+            }
+        }
+        return result;
+    }
+}

--- a/src/test/java/io/mvnpm/npm/model/PackageDeserializationTest.java
+++ b/src/test/java/io/mvnpm/npm/model/PackageDeserializationTest.java
@@ -1,8 +1,11 @@
 package io.mvnpm.npm.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -83,5 +86,47 @@ class PackageDeserializationTest {
         Package pkg = mapper.readValue(json, Package.class);
         assertNotNull(pkg);
         assertEquals("https://github.com/tanem/react-nprogress", pkg.homepage());
+    }
+
+    @Test
+    void timeMapWithUnpublishedObject() throws Exception {
+        String json = """
+                {
+                    "time": {
+                        "created": "2025-12-07T09:23:35.715Z",
+                        "modified": "2025-12-09T04:03:53.404Z",
+                        "90.9.0": "2025-12-07T09:23:35.961Z",
+                        "unpublished": {
+                            "time": "2025-12-09T04:03:53.404Z",
+                            "versions": ["90.9.0", "90.9.5"]
+                        }
+                    }
+                }
+                """;
+        Project project = mapper.readValue(json, Project.class);
+        assertNotNull(project);
+        Map<String, String> time = project.time();
+        assertNotNull(time);
+        assertEquals("2025-12-07T09:23:35.715Z", time.get("created"));
+        assertEquals("2025-12-09T04:03:53.404Z", time.get("modified"));
+        assertEquals("2025-12-07T09:23:35.961Z", time.get("90.9.0"));
+        assertFalse(time.containsKey("unpublished"), "Object entries should be skipped");
+    }
+
+    @Test
+    void timeMapWithOnlyStrings() throws Exception {
+        String json = """
+                {
+                    "time": {
+                        "created": "2025-01-01T00:00:00.000Z",
+                        "1.0.0": "2025-01-02T00:00:00.000Z"
+                    }
+                }
+                """;
+        Project project = mapper.readValue(json, Project.class);
+        assertNotNull(project);
+        assertEquals(2, project.time().size());
+        assertEquals("2025-01-01T00:00:00.000Z", project.time().get("created"));
+        assertEquals("2025-01-02T00:00:00.000Z", project.time().get("1.0.0"));
     }
 }


### PR DESCRIPTION
## Summary
- Add `TimeMapDeserializer` that skips non-string entries in the NPM `time` map
- NPM adds an `"unpublished"` key with an object value when a package is unpublished (e.g. `react-hook-form-5`), which caused `MismatchedInputException` since the map was typed as `Map<String, String>`

## Test plan
- [x] `PackageDeserializationTest.timeMapWithUnpublishedObject` — verifies object entries are skipped
- [x] `PackageDeserializationTest.timeMapWithOnlyStrings` — verifies normal string entries work
- [x] Full test suite passes (208 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)