### PR TITLE
Reduce NPM cache max size to prevent OOM evictions

### DIFF
--- a/src/main/java/io/mvnpm/npm/NpmRegistryFacade.java
+++ b/src/main/java/io/mvnpm/npm/NpmRegistryFacade.java
@@ -30,7 +30,7 @@ public class NpmRegistryFacade {
     NpmRegistryClient npmRegistryClient;
 
     // NOTE: Project metadata can be large (a few KB per entry after deserialization).
-    // Cache is bounded by npm-project-cache config (100k max, 1h TTL).
+    // Cache is bounded by npm-project-cache config (1k max, 1h TTL).
     @CacheResult(cacheName = "npm-project-cache")
     @Timeout(unit = ChronoUnit.SECONDS, value = 10)
     @Retry(maxRetries = 1)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,14 +35,14 @@ mvnpm.mavencentral.autorelease=true
 %dev.mvnpm.mavencentral.autorelease=false
 %test.mvnpm.mavencentral.autorelease=false
 
-quarkus.cache.caffeine."npm-project-cache".initial-capacity=100 
-quarkus.cache.caffeine."npm-project-cache".maximum-size=100000
+quarkus.cache.caffeine."npm-project-cache".initial-capacity=100
+quarkus.cache.caffeine."npm-project-cache".maximum-size=1000
 quarkus.cache.caffeine."npm-project-cache".expire-after-write=3600S
 %test.quarkus.cache.caffeine."npm-project-cache".expire-after-write=1S
 %dev.quarkus.cache.caffeine."npm-project-cache".expire-after-write=1S
 
-quarkus.cache.caffeine."npm-package-cache".initial-capacity=100 
-quarkus.cache.caffeine."npm-package-cache".maximum-size=100000
+quarkus.cache.caffeine."npm-package-cache".initial-capacity=100
+quarkus.cache.caffeine."npm-package-cache".maximum-size=500
 quarkus.cache.caffeine."npm-package-cache".expire-after-write=3600S
 %test.quarkus.cache.caffeine."npm-package-cache".expire-after-write=1S
 %dev.quarkus.cache.caffeine."npm-package-cache".expire-after-write=1S


### PR DESCRIPTION
## Summary

- Reduce `npm-project-cache` max size from 100,000 to 1,000 entries
- Reduce `npm-package-cache` max size from 100,000 to 500 entries
- Caffeine `maximum-size` controls entry count, not memory — with large NPM project metadata (a few KB each), 100K entries caused pods to use 2-5 GB and get OOM-evicted

## Context

Production pods were being evicted due to OOM. Investigation showed pods consuming 2-5 GB memory with 512Mi requests. Root cause: the Caffeine cache was configured to hold up to 100K entries of NPM project/package metadata, which can be several KB each after deserialization.

The new limits (1K projects, 500 packages) provide sufficient caching for hot paths while keeping memory bounded.

## Test plan

- [x] Verify build passes
- [x] Deployed to production — pods stable, no OOM evictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)