### PR TITLE
Throttle background sync to prevent OOM

### DIFF
--- a/src/main/java/io/mvnpm/mavencentral/sync/ContinuousSyncService.java
+++ b/src/main/java/io/mvnpm/mavencentral/sync/ContinuousSyncService.java
@@ -102,7 +102,7 @@ public class ContinuousSyncService {
             Log.debug("Starting error retry...");
             CentralSyncItem item;
             int count = 0;
-            while ((item = centralSyncItemService.claimNextForErrorRetry()) != null && count < 50) {
+            while ((item = centralSyncItemService.claimNextForErrorRetry()) != null && count < 10) {
                 bus.publish("central-sync-item-stage-change", item);
                 count++;
             }
@@ -115,11 +115,11 @@ public class ContinuousSyncService {
      * Check a batch of synced packages for updates using adaptive scheduling.
      * Replaces the old checkAll which loaded all rows into memory.
      */
-    @Scheduled(every = "${mvnpm.check-all.every:5m}", concurrentExecution = SKIP)
+    @Scheduled(every = "${mvnpm.check-all.every:10m}", concurrentExecution = SKIP)
     @RunOnVirtualThread
     public void checkAll() {
         try {
-            List<SyncedPackage> batch = claimBatchToCheck(50);
+            List<SyncedPackage> batch = claimBatchToCheck(10);
             if (batch.isEmpty()) {
                 Log.debug("No packages due for update check");
                 return;
@@ -128,7 +128,12 @@ public class ContinuousSyncService {
             for (SyncedPackage pkg : batch) {
                 LocalDateTime nextCheck = checkAndComputeNextCheck(pkg);
                 updateNextCheck(pkg, nextCheck);
+                // Throttle to let each package finish bundle creation and release memory
+                Thread.sleep(Duration.ofSeconds(10));
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Log.warn("Update check interrupted");
         } catch (Throwable t) {
             Log.error("Error during batch update check: " + t.getMessage());
         }


### PR DESCRIPTION
## Summary

- Reduce `checkAll` batch size from 50 to 10 packages per run
- Increase `checkAll` interval from 5m to 10m (with `concurrentExecution = SKIP`)
- Add 10s delay between packages to let bundle creation complete and release memory before starting the next
- Reduce `checkError` batch size from 50 to 10

## Context

After recent performance improvements (virtual threads, atomic claims), the sync pipeline processes packages faster, leading to memory bursts during `checkAll` when many packages have new versions. Each package triggers tgz download + JAR creation + source/javadoc/signature generation concurrently via event bus, causing OOM at 4Gi.

Throughput remains sufficient: 10 packages × 6 runs/hour = 60 packages/hour per pod.

## Test plan

- [x] All tests pass
- [ ] Deploy and monitor memory — expect pods to stay well under 4Gi limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)