### PR TITLE
Set native image heap limit to match pod memory

### DIFF
--- a/src/main/docker/Dockerfile.native-micro
+++ b/src/main/docker/Dockerfile.native-micro
@@ -29,4 +29,6 @@ COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
 EXPOSE 8080
 USER 1001
 
-ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0", "-Xmx8g"]
+ENV JAVA_MAX_HEAP=3g
+
+ENTRYPOINT ["sh", "-c", "./application -Dquarkus.http.host=0.0.0.0 -Xmx${JAVA_MAX_HEAP}"]


### PR DESCRIPTION
## Summary

- Change `-Xmx8g` to `-Xmx3g` (configurable via `JAVA_MAX_HEAP` env var)
- Was hardcoded to 8g but pod memory limit is 4Gi — JVM would allocate beyond the pod limit and get OOM-killed

## Context

The native image SubstrateVM was configured with `-Xmx8g` while pods have a 4Gi memory limit. The GC wouldn't collect aggressively enough because it thought it had 8GB available, leading to steady memory growth until OOM kill at 4Gi.

Default of 3g leaves ~1Gi for non-heap memory (thread stacks, native allocations, mmap'd files).

## Test plan

- [ ] Deploy and verify pods stay well under 4Gi

🤖 Generated with [Claude Code](https://claude.com/claude-code)