### PR TITLE
Handle workspace: protocol versions in VersionConverter

### DIFF
--- a/src/main/java/io/mvnpm/version/VersionConverter.java
+++ b/src/main/java/io/mvnpm/version/VersionConverter.java
@@ -101,7 +101,8 @@ public class VersionConverter {
                 versionString.startsWith("git:/") ||
                 versionString.startsWith("git+http") ||
                 versionString.startsWith("http://") ||
-                versionString.startsWith("https://")) { // We do not support git repos as version. Maybe something we can add later
+                versionString.startsWith("https://") ||
+                versionString.startsWith("workspace:")) { // We do not support git repos as version. Maybe something we can add later
             versionString = EMPTY;
         }
         return versionString;

--- a/src/test/java/io/mvnpm/VersionConverterTest.java
+++ b/src/test/java/io/mvnpm/VersionConverterTest.java
@@ -540,6 +540,13 @@ public class VersionConverterTest {
     }
 
     @Test
+    public void testWorkspaceVersion() {
+        Assertions.assertEquals("", VersionConverter.convert("workspace:*"));
+        Assertions.assertEquals("", VersionConverter.convert("workspace:^1.0.0"));
+        Assertions.assertEquals("", VersionConverter.convert("workspace:~1.2.3"));
+    }
+
+    @Test
     // Issue https://github.com/mvnpm/mvnpm/issues/36027
     public void testInvalidVersions() {
         Assertions.assertEquals("", VersionConverter.convert("${org.mvnpm-d3-time.version}"));


### PR DESCRIPTION
## Summary
- Treat `workspace:` versions (Yarn/PNPM workspace protocol) as unsupported in `VersionConverter`, same as `npm:`, `github:`, and git URL versions
- This was causing `bootstrap-touchspin:5.1.0` to get stuck in an infinite upload retry loop (119 attempts) because `workspace:*` threw `InvalidVersionException`

## Test plan
- [x] Added `testWorkspaceVersion` covering `workspace:*`, `workspace:^1.0.0`, `workspace:~1.2.3`
- [x] All existing `VersionConverterTest` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)