### PR TITLE
Fix desktop scroll on home page

### DIFF
--- a/src/main/resources/web/app/mvnpm-home.ts
+++ b/src/main/resources/web/app/mvnpm-home.ts
@@ -599,7 +599,8 @@ export class MvnpmHome extends ThemeMixin(LitElement) {
       /* --- Desktop SPA layout --- */
       @media (min-width: 769px) {
           :host {
-              overflow: hidden;
+              overflow-x: hidden;
+              overflow-y: auto;
           }
           .searchResults {
               flex: 1;


### PR DESCRIPTION
The `app.html` layout sets `overflow: hidden` on `main` at desktop width, expecting each web component to manage its own internal scrolling. However, `mvnpm-home` also had `overflow: hidden` on its `:host` at desktop width, so neither layer allowed scrolling — content below the fold (like the "Recently Synced" section) was completely unreachable.

This changes the home component's `:host` to `overflow-x: hidden; overflow-y: auto` so it scrolls internally when content overflows. Mobile layout is unaffected since the change is inside `@media (min-width: 769px)`.

Fixes #41646