### PR TITLE
Update Quarkus to 3.34.6 and bump Quarkiverse extensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.4</quarkus.platform.version>
+    <quarkus.platform.version>3.34.6</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
@@ -64,8 +64,8 @@
     
     <pgpainless.version>1.5.5</pgpainless.version>
     <!-- UI Libs -->
-    <quarkus-web-bundler.version>2.2.1</quarkus-web-bundler.version>
-    <quarkus-roq-frontmatter.version>2.0.5</quarkus-roq-frontmatter.version>
+    <quarkus-web-bundler.version>2.3.1</quarkus-web-bundler.version>
+    <quarkus-roq-frontmatter.version>2.1.0</quarkus-roq-frontmatter.version>
     <!-- Testing-->
     <playwright.version>0.0.1</playwright.version>
     <esbuild-java.version>2.1.0</esbuild-java.version>
@@ -240,21 +240,18 @@
     <dependency>
 	<groupId>org.mvnpm.at.qomponent</groupId>
 	<artifactId>qui-code-block</artifactId>
-	<version>1.1.1</version>
 	<scope>provided</scope>
     </dependency>
     <!-- Syntax highlighting for doc pages -->
     <dependency>
 	<groupId>org.mvnpm</groupId>
 	<artifactId>highlight.js</artifactId>
-	<version>11.11.1</version>
 	<scope>provided</scope>
     </dependency>
     <!-- To compare versions -->
     <dependency>
       <groupId>org.mvnpm</groupId>
       <artifactId>compare-versions</artifactId>
-      <version>6.1.1</version>
       <scope>provided</scope>
     </dependency>
     <!-- To render Markdown -->
@@ -267,21 +264,19 @@
     <dependency>
 	<groupId>org.mvnpm.at.qomponent</groupId>
 	<artifactId>qui-card</artifactId>
-	<version>1.0.2</version>
 	<scope>provided</scope>
     </dependency>
     <!-- Badges for display -->
     <dependency>
 	<groupId>org.mvnpm.at.qomponent</groupId>
 	<artifactId>qui-badge</artifactId>
-	<version>1.0.4</version>
 	<scope>provided</scope>
     </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>io.quarkiverse.roq</groupId>
       <artifactId>quarkus-roq-plugin-sitemap</artifactId>
-      <version>2.0.5</version>
+      <version>2.1.0</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -290,7 +285,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,7 +21,7 @@ quarkus.mcp-server.server-info.name=mvnpm
 quarkus.mcp-server.server-info.description=Maven repository facade for NPM packages. Search, browse, and resolve NPM packages as Maven dependencies. Get Maven coordinates, POMs, import maps, and track Maven Central sync status for any NPM package.
 quarkus.mcp-server.http.streamable.auto-init=true
 
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.websocket.dispatch-to-worker=true
 quarkus.scheduler.start-mode=forced
 


### PR DESCRIPTION
Upgrades the Quarkus platform from 3.32.4 to 3.34.6, along with Quarkiverse extensions (web-bundler 2.3.1, roq-frontmatter 2.1.0, roq-plugin-sitemap 2.1.0). Also fixes the deprecated `quarkus.http.cors` property, renames the relocated `quarkus-junit5-mockito` artifact, and lets the mvnpm-locker BOM manage frontend dependency versions instead of pinning them explicitly.