### PR TITLE
Restore explicit versions on frontend dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,18 +240,21 @@
     <dependency>
 	<groupId>org.mvnpm.at.qomponent</groupId>
 	<artifactId>qui-code-block</artifactId>
+	<version>1.1.1</version>
 	<scope>provided</scope>
     </dependency>
     <!-- Syntax highlighting for doc pages -->
     <dependency>
 	<groupId>org.mvnpm</groupId>
 	<artifactId>highlight.js</artifactId>
+	<version>11.11.1</version>
 	<scope>provided</scope>
     </dependency>
     <!-- To compare versions -->
     <dependency>
       <groupId>org.mvnpm</groupId>
       <artifactId>compare-versions</artifactId>
+      <version>6.1.1</version>
       <scope>provided</scope>
     </dependency>
     <!-- To render Markdown -->
@@ -264,12 +267,14 @@
     <dependency>
 	<groupId>org.mvnpm.at.qomponent</groupId>
 	<artifactId>qui-card</artifactId>
+	<version>1.0.2</version>
 	<scope>provided</scope>
     </dependency>
     <!-- Badges for display -->
     <dependency>
 	<groupId>org.mvnpm.at.qomponent</groupId>
 	<artifactId>qui-badge</artifactId>
+	<version>1.0.4</version>
 	<scope>provided</scope>
     </dependency>
     <!-- Testing -->


### PR DESCRIPTION
The Quarkus update in #41648 let OpenRewrite remove explicit versions from 5 frontend dependencies (qui-code-block, highlight.js, compare-versions, qui-card, qui-badge), assuming the mvnpm-locker BOM would manage them. However, the release workflow runs `locker-maven-plugin:lock` before the locker BOM is available, so the POM must be self-contained. This restores those versions to fix the 5.1.9 release failure.