### PR TITLE
Strip Cache-Control on non-200 responses

### DIFF
--- a/src/main/java/io/mvnpm/ui/SPARouting.java
+++ b/src/main/java/io/mvnpm/ui/SPARouting.java
@@ -3,6 +3,7 @@ package io.mvnpm.ui;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
+import io.netty.handler.codec.http.HttpStatusClass;
 import io.vertx.ext.web.Router;
 
 @ApplicationScoped
@@ -10,6 +11,12 @@ public class SPARouting {
 
     public void init(@Observes Router router) {
         router.get("/*").handler(rc -> {
+            // Workaround for https://github.com/quarkusio/quarkus/issues/54272
+            rc.addHeadersEndHandler(v -> {
+                if (!HttpStatusClass.SUCCESS.contains(rc.response().getStatusCode())) {
+                    rc.response().headers().remove("Cache-Control");
+                }
+            });
             final String path = rc.normalizedPath();
             if (path.startsWith("/package/") || path.startsWith("/search/")) {
                 rc.reroute("/");


### PR DESCRIPTION
## Summary
- Strip `Cache-Control` headers from non-200 responses to prevent CDNs from caching error responses with aggressive cache headers
- Workaround for https://github.com/quarkusio/quarkus/issues/54272