### PR TITLE
Keep maven-resolver producer beans in the native image

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,9 +17,12 @@ quarkus.rest-client.mavencentral.connect-timeout=30000
 quarkus.rest-client.github.url=https://api.github.com
 quarkus.rest-client.github.verify-host=false
 
-##### Self-Hosting Properties (uncomment on self-hosting):
+##### The maven-resolver extension contributes these producer beans. They must stay in the image even
+##### when the custom repository is disabled: otherwise ArC removes them as unused and the native build
+##### fails in the extension's static-init recorder looking them up (see #41662).
+quarkus.arc.unremovable-types=io.quarkiverse.mavenresolver.MavenRepositorySystemProducer,io.quarkiverse.mavenresolver.BootstrapMavenContextProducer
 
-# quarkus.arc.unremovable-types=io.quarkiverse.mavenresolver.MavenRepositorySystemProducer,io.quarkiverse.mavenresolver.BootstrapMavenContextProducer
+##### Self-Hosting Properties (uncomment on self-hosting):
 
 ##### change on self-hosted instances to e.g. https://nexus.example.org/repository/maven-public
 


### PR DESCRIPTION
The native image build has been failing with `No bean found for MavenRepositorySystemProducer` in the quarkus-maven-resolver extension's static-init recorder.

The extension registers `MavenRepositorySystemProducer` and `BootstrapMavenContextProducer` and looks them up from a build-time recorder. When the custom repository is disabled (the default), nothing injects `BootstrapMavenContext`, so ArC removes those beans as unused and the native build fails. The `quarkus.arc.unremovable-types` entry that keeps them was only active in the test configuration, which is why the JVM tests passed while the native build did not.

This makes that entry always active in the main configuration so the producer beans stay in the production/native image regardless of the feature flag. It only prevents bean removal and does not eagerly initialise the repository system, so the default Maven Central path is unaffected.

This is the mvnpm-side adaptation that quarkiverse/quarkus-maven-resolver#51 was working around, so that PR can be closed as not needed once this is confirmed green.

Fixes #41662
